### PR TITLE
Epic 01: Core Bucket MVP

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Core Services
@@ -28,6 +29,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var panelWindow: SnorOhPanelWindow?
     private let settingsWindow = SettingsWindow()
 
+    // MARK: - Bucket (Epic 01)
+    private var bucketObserver: NSObjectProtocol?
+
     // MARK: - Lifecycle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -37,6 +41,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         CustomOhhManager.shared.load()
+        BucketManager.shared.load()
         loadSavedPreferences()
         runSetup()
         startHTTPServer()
@@ -48,6 +53,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenuBar()
         createPanel()
         startBubbleObserving()
+        startBucketFeature()
 
         // Transition from initializing → searching after a short delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
@@ -61,20 +67,61 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Welcome bubble after brief delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             self.bubbleManager.showWelcome()
+
+            // First-launch bucket tip — fires once, then never again.
+            let tipKey = DefaultsKey.bucketTipShown
+            if !UserDefaults.standard.bool(forKey: tipKey) {
+                UserDefaults.standard.set(true, forKey: tipKey)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                    self.bubbleManager.show("Drop anything onto me to bucket it!", durationMs: 6000)
+                }
+            }
         }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         spriteEngine.stop()
         mcpReactWork?.cancel()
-        for observer in [mcpSayObserver, taskCompletedObserver, mcpReactObserver, trayObserver].compactMap({ $0 }) {
+        for observer in [mcpSayObserver, taskCompletedObserver, mcpReactObserver, trayObserver, bucketObserver].compactMap({ $0 }) {
             NotificationCenter.default.removeObserver(observer)
         }
         if let obs = statusBarObserver { NotificationCenter.default.removeObserver(obs) }
+        ClipboardMonitor.shared.stop()
+        HotkeyRegistrar.shared.unregister()
         peerDiscovery?.stop()
         watchdog?.stop()
         httpServer?.stop()
         gitPoller?.stop()
+    }
+
+    // MARK: - Bucket Feature (Epic 01)
+
+    private func startBucketFeature() {
+        // Start clipboard monitor (respects BucketSettings.captureClipboard)
+        ClipboardMonitor.shared.start()
+
+        // Global hotkey toggles panel + focuses Bucket tab
+        let binding = BucketManager.shared.settings.hotkey
+        HotkeyRegistrar.shared.registerBucketToggle(binding: binding) { [weak self] in
+            self?.toggleBucketPanel()
+        }
+
+        // Status bar reflects bucket count too
+        bucketObserver = NotificationCenter.default.addObserver(
+            forName: .bucketChanged, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.updateStatusBarText()
+        }
+    }
+
+    /// Global-hotkey action: shows the panel (if hidden) and flips its tab to Bucket.
+    private func toggleBucketPanel() {
+        UserDefaults.standard.set("bucket", forKey: DefaultsKey.bucketActiveTab)
+        if panelWindow?.isVisible == true {
+            panelWindow?.orderOut(nil)
+        } else {
+            panelWindow?.orderFront(nil)
+        }
     }
 
     // MARK: - HTTP Server
@@ -137,8 +184,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func updateStatusBarText() {
         guard let button = statusItem?.button else { return }
         let projects = sessionManager.projects
+        let bucketCount = BucketManager.shared.activeBucket.items.count
 
-        if projects.isEmpty {
+        if projects.isEmpty && bucketCount == 0 {
             button.attributedTitle = NSAttributedString()
             return
         }
@@ -155,7 +203,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         counts = sorted.map { ($0.key, $0.value) }
 
-        // Build attributed string: " ● 2 ● 1 ● 1"
+        // Build attributed string: " ● 2 ● 1 ● 1   📦 3"
         let result = NSMutableAttributedString()
         let space = NSAttributedString(string: " ")
 
@@ -181,6 +229,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ]
             )
             result.append(countStr)
+        }
+
+        if bucketCount > 0 {
+            if !counts.isEmpty {
+                result.append(NSAttributedString(string: "  "))
+            } else {
+                result.append(space)
+            }
+            let bucketDot = NSAttributedString(
+                string: "\u{25CF}",
+                attributes: [
+                    .foregroundColor: NSColor.systemOrange,
+                    .font: NSFont.systemFont(ofSize: 7, weight: .bold),
+                    .baselineOffset: 1.0,
+                ]
+            )
+            result.append(bucketDot)
+            result.append(NSAttributedString(
+                string: "\(bucketCount)",
+                attributes: [
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                    .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .medium),
+                ]
+            ))
         }
 
         button.attributedTitle = result

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -88,6 +88,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let obs = statusBarObserver { NotificationCenter.default.removeObserver(obs) }
         ClipboardMonitor.shared.stop()
         HotkeyRegistrar.shared.unregister()
+
+        // Flush any pending debounced bucket write synchronously (bounded wait)
+        // so a quit mid-debounce doesn't lose the latest mutation.
+        let sema = DispatchSemaphore(value: 0)
+        Task { @MainActor in
+            await BucketManager.shared.flushPendingWrites()
+            sema.signal()
+        }
+        _ = sema.wait(timeout: .now() + .milliseconds(500))
+
         peerDiscovery?.stop()
         watchdog?.stop()
         httpServer?.stop()

--- a/Sources/Core/BucketDropHandler.swift
+++ b/Sources/Core/BucketDropHandler.swift
@@ -23,7 +23,8 @@ enum BucketDropHandler {
 
     /// Entry point called from `.onDrop(of:supportedUTTypes)` closures.
     /// Returns `true` synchronously so SwiftUI accepts the drop; real work
-    /// happens asynchronously as providers resolve.
+    /// happens asynchronously as providers resolve (and, for files/images,
+    /// as sidecar copies complete).
     @discardableResult
     static func ingest(providers: [NSItemProvider], source: BucketChangeSource) -> Bool {
         guard !providers.isEmpty else { return false }
@@ -31,124 +32,74 @@ enum BucketDropHandler {
 
         for provider in providers {
             Task { @MainActor in
-                if let item = await resolveItem(from: provider, stackGroupID: groupID) {
-                    BucketManager.shared.add(item, source: source)
-                }
+                await resolveAndInsert(from: provider, source: source, stackGroupID: groupID)
             }
         }
         return true
     }
 
-    // MARK: - Provider → Item
+    // MARK: - Provider resolution + insertion
 
-    private static func resolveItem(
+    private static func resolveAndInsert(
         from provider: NSItemProvider,
+        source: BucketChangeSource,
         stackGroupID: UUID?
-    ) async -> BucketItem? {
-        // 1. File URL (files + folders)
+    ) async {
+        let manager = BucketManager.shared
+
+        // 1. File URL (files + folders) — routes through `add(fileAt:)` which
+        //    copies the sidecar before insert.
         if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
             if let url = await loadFileURL(from: provider) {
-                return makeFileItem(at: url, stackGroupID: stackGroupID)
+                await manager.add(fileAt: url, source: source, stackGroupID: stackGroupID)
+                return
             }
         }
 
-        // 2. Image bytes
+        // 2. Image bytes — writes sidecar PNG, then inserts.
         if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
             if let data = await loadData(from: provider, type: UTType.image.identifier) {
-                return makeImageItem(data: data, stackGroupID: stackGroupID)
+                await manager.add(imageData: data, source: source, stackGroupID: stackGroupID)
+                return
             }
         }
 
-        // 3. Web URL (not file URL)
+        // 3. Web URL (not file URL) — no sidecar needed.
         if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
             if let url = await loadURL(from: provider), !url.isFileURL {
-                return makeURLItem(urlString: url.absoluteString, stackGroupID: stackGroupID)
+                let item = BucketItem(
+                    kind: .url,
+                    stackGroupID: stackGroupID,
+                    urlMeta: .init(urlString: url.absoluteString, title: nil)
+                )
+                manager.add(item, source: source)
+                return
             }
         }
 
-        // 4. Rich text (RTF)
+        // 4. Rich text (RTF) — stored inline (base64 in `text`).
         if provider.hasItemConformingToTypeIdentifier(UTType.rtf.identifier) {
             if let data = await loadData(from: provider, type: UTType.rtf.identifier) {
-                return makeRichTextItem(rtfData: data, stackGroupID: stackGroupID)
+                let item = BucketItem(
+                    kind: .richText,
+                    stackGroupID: stackGroupID,
+                    text: data.base64EncodedString()
+                )
+                manager.add(item, source: source)
+                return
             }
         }
 
-        // 5. Plain text
+        // 5. Plain text — stored inline.
         for id in [UTType.utf8PlainText.identifier, UTType.plainText.identifier] {
             if provider.hasItemConformingToTypeIdentifier(id) {
                 if let s = await loadString(from: provider, type: id) {
-                    return BucketItem(kind: .text, stackGroupID: stackGroupID, text: s)
+                    let item = BucketItem(kind: .text, stackGroupID: stackGroupID, text: s)
+                    manager.add(item, source: source)
+                    return
                 }
             }
         }
-
-        return nil
-    }
-
-    // MARK: - Factories
-
-    /// Creates a file/folder item, kicking off an async copy into the bucket
-    /// sidecar. The returned item has `cachedPath = nil` until the copy finishes;
-    /// BucketManager will see the initial item and update it after copy.
-    private static func makeFileItem(at url: URL, stackGroupID: UUID?) -> BucketItem {
-        var isDir: ObjCBool = false
-        FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
-        let kind: BucketItemKind = isDir.boolValue ? .folder : inferFileKind(url: url)
-        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init) ?? 0
-        let uti = (try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier)
-            ?? (isDir.boolValue ? "public.folder" : "public.data")
-        return BucketItem(
-            id: UUID(),
-            kind: kind,
-            stackGroupID: stackGroupID,
-            fileRef: .init(
-                originalPath: url.path,
-                cachedPath: nil,
-                byteSize: size,
-                uti: uti,
-                displayName: url.lastPathComponent
-            )
-        )
-    }
-
-    private static func inferFileKind(url: URL) -> BucketItemKind {
-        if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
-           let t = UTType(uti) {
-            if t.conforms(to: .image) { return .image }
-        }
-        return .file
-    }
-
-    private static func makeImageItem(data: Data, stackGroupID: UUID?) -> BucketItem {
-        let id = UUID()
-        return BucketItem(
-            id: id,
-            kind: .image,
-            stackGroupID: stackGroupID,
-            fileRef: .init(
-                originalPath: "", // no original path for pasteboard-supplied bytes
-                cachedPath: nil,
-                byteSize: Int64(data.count),
-                uti: UTType.image.identifier,
-                displayName: "image-\(id.uuidString.prefix(8)).png"
-            )
-        )
-    }
-
-    private static func makeURLItem(urlString: String, stackGroupID: UUID?) -> BucketItem {
-        BucketItem(
-            kind: .url,
-            stackGroupID: stackGroupID,
-            urlMeta: .init(urlString: urlString, title: nil)
-        )
-    }
-
-    private static func makeRichTextItem(rtfData: Data, stackGroupID: UUID?) -> BucketItem {
-        BucketItem(
-            kind: .richText,
-            stackGroupID: stackGroupID,
-            text: rtfData.base64EncodedString()
-        )
     }
 
     // MARK: - Async NSItemProvider loaders

--- a/Sources/Core/BucketDropHandler.swift
+++ b/Sources/Core/BucketDropHandler.swift
@@ -1,0 +1,214 @@
+import Foundation
+import AppKit
+import UniformTypeIdentifiers
+
+/// Unpacks `NSItemProvider`s coming from SwiftUI `.onDrop(of:...)` into
+/// `BucketItem`s and adds them to `BucketManager.shared`.
+///
+/// Priority (highest first): file URL > image bytes > web URL > rich text > plain text.
+/// A single drop of N providers becomes N items sharing a `stackGroupID` if N > 1.
+@MainActor
+enum BucketDropHandler {
+
+    /// UTTypes offered to SwiftUI's `.onDrop(of:)` matcher. Keep aligned with
+    /// the `ingest(providers:source:)` switch below.
+    static let supportedUTTypes: [UTType] = [
+        .fileURL,
+        .image,
+        .url,
+        .rtf,
+        .utf8PlainText,
+        .plainText,
+    ]
+
+    /// Entry point called from `.onDrop(of:supportedUTTypes)` closures.
+    /// Returns `true` synchronously so SwiftUI accepts the drop; real work
+    /// happens asynchronously as providers resolve.
+    @discardableResult
+    static func ingest(providers: [NSItemProvider], source: BucketChangeSource) -> Bool {
+        guard !providers.isEmpty else { return false }
+        let groupID: UUID? = providers.count > 1 ? UUID() : nil
+
+        for provider in providers {
+            Task { @MainActor in
+                if let item = await resolveItem(from: provider, stackGroupID: groupID) {
+                    BucketManager.shared.add(item, source: source)
+                }
+            }
+        }
+        return true
+    }
+
+    // MARK: - Provider → Item
+
+    private static func resolveItem(
+        from provider: NSItemProvider,
+        stackGroupID: UUID?
+    ) async -> BucketItem? {
+        // 1. File URL (files + folders)
+        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+            if let url = await loadFileURL(from: provider) {
+                return makeFileItem(at: url, stackGroupID: stackGroupID)
+            }
+        }
+
+        // 2. Image bytes
+        if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+            if let data = await loadData(from: provider, type: UTType.image.identifier) {
+                return makeImageItem(data: data, stackGroupID: stackGroupID)
+            }
+        }
+
+        // 3. Web URL (not file URL)
+        if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+            if let url = await loadURL(from: provider), !url.isFileURL {
+                return makeURLItem(urlString: url.absoluteString, stackGroupID: stackGroupID)
+            }
+        }
+
+        // 4. Rich text (RTF)
+        if provider.hasItemConformingToTypeIdentifier(UTType.rtf.identifier) {
+            if let data = await loadData(from: provider, type: UTType.rtf.identifier) {
+                return makeRichTextItem(rtfData: data, stackGroupID: stackGroupID)
+            }
+        }
+
+        // 5. Plain text
+        for id in [UTType.utf8PlainText.identifier, UTType.plainText.identifier] {
+            if provider.hasItemConformingToTypeIdentifier(id) {
+                if let s = await loadString(from: provider, type: id) {
+                    return BucketItem(kind: .text, stackGroupID: stackGroupID, text: s)
+                }
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Factories
+
+    /// Creates a file/folder item, kicking off an async copy into the bucket
+    /// sidecar. The returned item has `cachedPath = nil` until the copy finishes;
+    /// BucketManager will see the initial item and update it after copy.
+    private static func makeFileItem(at url: URL, stackGroupID: UUID?) -> BucketItem {
+        var isDir: ObjCBool = false
+        FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+        let kind: BucketItemKind = isDir.boolValue ? .folder : inferFileKind(url: url)
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init) ?? 0
+        let uti = (try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier)
+            ?? (isDir.boolValue ? "public.folder" : "public.data")
+        return BucketItem(
+            id: UUID(),
+            kind: kind,
+            stackGroupID: stackGroupID,
+            fileRef: .init(
+                originalPath: url.path,
+                cachedPath: nil,
+                byteSize: size,
+                uti: uti,
+                displayName: url.lastPathComponent
+            )
+        )
+    }
+
+    private static func inferFileKind(url: URL) -> BucketItemKind {
+        if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
+           let t = UTType(uti) {
+            if t.conforms(to: .image) { return .image }
+        }
+        return .file
+    }
+
+    private static func makeImageItem(data: Data, stackGroupID: UUID?) -> BucketItem {
+        let id = UUID()
+        return BucketItem(
+            id: id,
+            kind: .image,
+            stackGroupID: stackGroupID,
+            fileRef: .init(
+                originalPath: "", // no original path for pasteboard-supplied bytes
+                cachedPath: nil,
+                byteSize: Int64(data.count),
+                uti: UTType.image.identifier,
+                displayName: "image-\(id.uuidString.prefix(8)).png"
+            )
+        )
+    }
+
+    private static func makeURLItem(urlString: String, stackGroupID: UUID?) -> BucketItem {
+        BucketItem(
+            kind: .url,
+            stackGroupID: stackGroupID,
+            urlMeta: .init(urlString: urlString, title: nil)
+        )
+    }
+
+    private static func makeRichTextItem(rtfData: Data, stackGroupID: UUID?) -> BucketItem {
+        BucketItem(
+            kind: .richText,
+            stackGroupID: stackGroupID,
+            text: rtfData.base64EncodedString()
+        )
+    }
+
+    // MARK: - Async NSItemProvider loaders
+
+    private static func loadFileURL(from provider: NSItemProvider) async -> URL? {
+        await withCheckedContinuation { cont in
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                    cont.resume(returning: url); return
+                }
+                if let url = item as? URL {
+                    cont.resume(returning: url); return
+                }
+                cont.resume(returning: nil)
+            }
+        }
+    }
+
+    private static func loadURL(from provider: NSItemProvider) async -> URL? {
+        await withCheckedContinuation { cont in
+            provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+                if let url = item as? URL {
+                    cont.resume(returning: url); return
+                }
+                if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                    cont.resume(returning: url); return
+                }
+                if let s = item as? String, let url = URL(string: s) {
+                    cont.resume(returning: url); return
+                }
+                cont.resume(returning: nil)
+            }
+        }
+    }
+
+    private static func loadData(from provider: NSItemProvider, type: String) async -> Data? {
+        await withCheckedContinuation { cont in
+            provider.loadItem(forTypeIdentifier: type, options: nil) { item, _ in
+                if let data = item as? Data {
+                    cont.resume(returning: data); return
+                }
+                if let url = item as? URL, let data = try? Data(contentsOf: url) {
+                    cont.resume(returning: data); return
+                }
+                cont.resume(returning: nil)
+            }
+        }
+    }
+
+    private static func loadString(from provider: NSItemProvider, type: String) async -> String? {
+        await withCheckedContinuation { cont in
+            provider.loadItem(forTypeIdentifier: type, options: nil) { item, _ in
+                if let s = item as? String {
+                    cont.resume(returning: s); return
+                }
+                if let data = item as? Data, let s = String(data: data, encoding: .utf8) {
+                    cont.resume(returning: s); return
+                }
+                cont.resume(returning: nil)
+            }
+        }
+    }
+}

--- a/Sources/Core/BucketManager.swift
+++ b/Sources/Core/BucketManager.swift
@@ -34,12 +34,17 @@ final class BucketManager {
     private var loaded = false
     private var persistDebounce: Task<Void, Never>?
 
+    /// The root of on-disk bucket storage — exposed so views can resolve
+    /// sidecar thumbnails without awaiting the store actor. Captured at init.
+    nonisolated let storeRootURL: URL
+
     // MARK: - Init
 
     /// Designated init. Production uses `.shared`; tests construct their own
     /// with an isolated temp-dir `BucketStore`.
     init(store: BucketStore = BucketStore()) {
         self.store = store
+        self.storeRootURL = store.rootURL
     }
 
     // MARK: - Lifecycle

--- a/Sources/Core/BucketManager.swift
+++ b/Sources/Core/BucketManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import UniformTypeIdentifiers
 
 /// Core state holder for the Bucket feature.
 ///
@@ -86,32 +87,106 @@ final class BucketManager {
         schedulePersist()
     }
 
+    /// Async entry point for file drops. Copies the source into the sidecar
+    /// directory **before** inserting, so the item's `cachedPath` is populated
+    /// and the bucket survives restart.
+    func add(fileAt url: URL, source: BucketChangeSource, stackGroupID: UUID? = nil) async {
+        var isDir: ObjCBool = false
+        FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+        let kind = classifyFile(url: url, isDirectory: isDir.boolValue)
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize).map(Int64.init) ?? 0
+        let uti = (try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier)
+            ?? (isDir.boolValue ? "public.folder" : "public.data")
+
+        let itemID = UUID()
+        var cachedPath: String? = nil
+        if !isDir.boolValue {
+            let subdir = kind == .image ? "images" : "files"
+            cachedPath = try? await store.copySidecar(
+                from: url,
+                itemID: itemID,
+                subdir: subdir
+            )
+        }
+
+        let item = BucketItem(
+            id: itemID,
+            kind: kind,
+            stackGroupID: stackGroupID,
+            fileRef: .init(
+                originalPath: url.path,
+                cachedPath: cachedPath,
+                byteSize: size,
+                uti: uti,
+                displayName: url.lastPathComponent
+            )
+        )
+        add(item, source: source)
+    }
+
+    /// Async entry point for raw image bytes (pasteboard image drops).
+    /// Writes the PNG bytes into the sidecar and inserts with `cachedPath` set.
+    func add(imageData data: Data, source: BucketChangeSource, stackGroupID: UUID? = nil) async {
+        let itemID = UUID()
+        let cachedPath = try? await store.writeSidecar(
+            data,
+            itemID: itemID,
+            subdir: "images",
+            ext: "png"
+        )
+        let item = BucketItem(
+            id: itemID,
+            kind: .image,
+            stackGroupID: stackGroupID,
+            fileRef: .init(
+                originalPath: "",
+                cachedPath: cachedPath,
+                byteSize: Int64(data.count),
+                uti: "public.png",
+                displayName: "image-\(itemID.uuidString.prefix(8)).png"
+            )
+        )
+        add(item, source: source)
+    }
+
+    private func classifyFile(url: URL, isDirectory: Bool) -> BucketItemKind {
+        if isDirectory { return .folder }
+        if let uti = (try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier),
+           let t = UTType(uti), t.conforms(to: .image) {
+            return .image
+        }
+        return .file
+    }
+
     /// Removes by ID; deletes any sidecar files.
-    func remove(id: UUID) {
+    /// `source` defaults to `.panel` since most callers are UI-driven, but can
+    /// be overridden (e.g. from peer-sync or watched-folder cleanup in later
+    /// epics) so Epic 02's catch reaction picks the right intensity.
+    func remove(id: UUID, source: BucketChangeSource = .panel) {
         guard let idx = activeBucket.items.firstIndex(where: { $0.id == id }) else { return }
         let removed = activeBucket.items.remove(at: idx)
         cleanupSidecars(for: [removed])
-        postChanged(change: .removed, source: .panel, itemID: id)
+        postChanged(change: .removed, source: source, itemID: id)
         schedulePersist()
     }
 
     /// Toggles `pinned`; pinned items are never auto-evicted and never
     /// removed by `clearUnpinned()`.
-    func togglePin(id: UUID) {
+    func togglePin(id: UUID, source: BucketChangeSource = .panel) {
         guard let idx = activeBucket.items.firstIndex(where: { $0.id == id }) else { return }
         activeBucket.items[idx].pinned.toggle()
         let kind: BucketChangeKind = activeBucket.items[idx].pinned ? .pinned : .unpinned
-        postChanged(change: kind, source: .panel, itemID: id)
+        postChanged(change: kind, source: source, itemID: id)
         schedulePersist()
     }
 
     /// Removes all unpinned items and their sidecars.
-    func clearUnpinned() {
+    func clearUnpinned(source: BucketChangeSource = .panel) {
         let removed = activeBucket.items.filter { !$0.pinned }
         guard !removed.isEmpty else { return }
         activeBucket.items.removeAll { !$0.pinned }
         cleanupSidecars(for: removed)
-        postChanged(change: .cleared, source: .panel, itemID: nil)
+        postChanged(change: .cleared, source: source, itemID: nil)
         schedulePersist()
     }
 
@@ -209,24 +284,15 @@ final class BucketManager {
     }
 
     private func cleanupSidecars(for items: [BucketItem]) {
-        let paths = items.compactMap { item -> String? in
-            [
-                item.fileRef?.cachedPath,
-                item.urlMeta?.faviconPath,
-                item.urlMeta?.ogImagePath,
-            ].compactMap { $0 }.joined(separator: "\n").isEmpty ? nil : nil
-        }
-        // The reduce above is noise; gather flat list explicitly:
-        var flat: [String] = []
+        var paths: [String] = []
         for item in items {
-            if let p = item.fileRef?.cachedPath { flat.append(p) }
-            if let p = item.urlMeta?.faviconPath { flat.append(p) }
-            if let p = item.urlMeta?.ogImagePath { flat.append(p) }
+            if let p = item.fileRef?.cachedPath { paths.append(p) }
+            if let p = item.urlMeta?.faviconPath { paths.append(p) }
+            if let p = item.urlMeta?.ogImagePath { paths.append(p) }
         }
-        _ = paths // silence unused warning; kept for future "returning removed paths" hook
-        guard !flat.isEmpty else { return }
+        guard !paths.isEmpty else { return }
         Task { [store] in
-            await store.deleteSidecars(relativePaths: flat)
+            await store.deleteSidecars(relativePaths: paths)
         }
     }
 
@@ -266,11 +332,18 @@ final class BucketManager {
         }
     }
 
-    /// Tests use this to deterministically flush pending debounced writes.
-    func flushForTests() async {
+    /// Cancels any pending debounced write and flushes current state to disk.
+    /// Called from `applicationWillTerminate` to avoid losing a mutation that
+    /// arrived within the 500 ms debounce window.
+    func flushPendingWrites() async {
         persistDebounce?.cancel()
         let snapshot = activeBucket
         try? await store.saveBucket(snapshot)
         try? await store.saveSettings(settings)
+    }
+
+    /// Test alias for `flushPendingWrites()`. Kept so existing tests compile.
+    func flushForTests() async {
+        await flushPendingWrites()
     }
 }

--- a/Sources/Core/BucketManager.swift
+++ b/Sources/Core/BucketManager.swift
@@ -1,0 +1,271 @@
+import Foundation
+import AppKit
+
+/// Core state holder for the Bucket feature.
+///
+/// Runs on `@MainActor` because SwiftUI observes its state. Disk I/O is
+/// delegated to a `BucketStore` actor so the UI thread never blocks.
+///
+/// Lifecycle mirrors `CustomOhhManager`:
+///  1. `AppDelegate.applicationDidFinishLaunching` calls `.shared.load()`.
+///  2. UI reads `activeBucket` / `settings` via `@Observable`.
+///  3. Mutations (`add`, `remove`, `togglePin`, …) update state synchronously,
+///     post `.bucketChanged`, and schedule a debounced persist.
+@Observable
+@MainActor
+final class BucketManager {
+
+    // MARK: - Singleton
+
+    static let shared = BucketManager()
+
+    // MARK: - State
+
+    private(set) var activeBucket: Bucket = Bucket(name: "Default")
+    private(set) var settings: BucketSettings = BucketSettings()
+
+    /// Present-only-in-tests hook to wait on the pending persist debounce.
+    /// Production callers should never need this.
+    var persistInFlight: Task<Void, Never>?
+
+    // MARK: - Private
+
+    private let store: BucketStore
+    private var loaded = false
+    private var persistDebounce: Task<Void, Never>?
+
+    // MARK: - Init
+
+    /// Designated init. Production uses `.shared`; tests construct their own
+    /// with an isolated temp-dir `BucketStore`.
+    init(store: BucketStore = BucketStore()) {
+        self.store = store
+    }
+
+    // MARK: - Lifecycle
+
+    /// Called from `AppDelegate` at launch. Synchronous fire-and-forget —
+    /// UI renders the default empty bucket until disk load resolves.
+    func load() {
+        guard !loaded else { return }
+        loaded = true
+        Task { [weak self] in
+            await self?.loadAsync()
+        }
+    }
+
+    private func loadAsync() async {
+        do {
+            let b = try await store.loadBucket()
+            let s = try await store.loadSettings()
+            self.activeBucket = b
+            self.settings = s
+        } catch {
+            NSLog("[bucket] load failed: \(error)")
+        }
+    }
+
+    // MARK: - Mutations
+
+    /// Inserts an item at the head (newest-first), fires `.bucketChanged`,
+    /// enforces LRU caps, schedules a persist.
+    func add(_ item: BucketItem, source: BucketChangeSource) {
+        // Dedupe against immediate previous item (clipboard noise).
+        if let head = activeBucket.items.first,
+           dedupeMatches(newItem: item, existing: head) {
+            return
+        }
+        activeBucket.items.insert(item, at: 0)
+        evictIfNeeded()
+        postChanged(change: .added, source: source, itemID: item.id)
+        schedulePersist()
+    }
+
+    /// Removes by ID; deletes any sidecar files.
+    func remove(id: UUID) {
+        guard let idx = activeBucket.items.firstIndex(where: { $0.id == id }) else { return }
+        let removed = activeBucket.items.remove(at: idx)
+        cleanupSidecars(for: [removed])
+        postChanged(change: .removed, source: .panel, itemID: id)
+        schedulePersist()
+    }
+
+    /// Toggles `pinned`; pinned items are never auto-evicted and never
+    /// removed by `clearUnpinned()`.
+    func togglePin(id: UUID) {
+        guard let idx = activeBucket.items.firstIndex(where: { $0.id == id }) else { return }
+        activeBucket.items[idx].pinned.toggle()
+        let kind: BucketChangeKind = activeBucket.items[idx].pinned ? .pinned : .unpinned
+        postChanged(change: kind, source: .panel, itemID: id)
+        schedulePersist()
+    }
+
+    /// Removes all unpinned items and their sidecars.
+    func clearUnpinned() {
+        let removed = activeBucket.items.filter { !$0.pinned }
+        guard !removed.isEmpty else { return }
+        activeBucket.items.removeAll { !$0.pinned }
+        cleanupSidecars(for: removed)
+        postChanged(change: .cleared, source: .panel, itemID: nil)
+        schedulePersist()
+    }
+
+    /// Fuzzy-ish filter across text, URL string, URL title, file display name,
+    /// and `sourceBundleID`. Case-insensitive, no ranking.
+    func search(_ query: String) -> [BucketItem] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return activeBucket.items }
+        let needle = q.lowercased()
+        return activeBucket.items.filter { item in
+            if item.text?.lowercased().contains(needle) == true { return true }
+            if item.urlMeta?.urlString.lowercased().contains(needle) == true { return true }
+            if item.urlMeta?.title?.lowercased().contains(needle) == true { return true }
+            if item.fileRef?.displayName.lowercased().contains(needle) == true { return true }
+            if item.sourceBundleID?.lowercased().contains(needle) == true { return true }
+            return false
+        }
+    }
+
+    // MARK: - Settings
+
+    func updateSettings(_ new: BucketSettings) {
+        self.settings = new
+        evictIfNeeded()
+        Task { [store] in
+            try? await store.saveSettings(new)
+        }
+    }
+
+    // MARK: - Dedupe helper (clipboard-focused)
+
+    /// Two items are "same" for clipboard-dedupe purposes if they're text
+    /// with equal payloads, URLs with equal URL strings, or colors with equal
+    /// hex. File/image items are never deduped (source path matters).
+    private func dedupeMatches(newItem: BucketItem, existing: BucketItem) -> Bool {
+        guard newItem.kind == existing.kind else { return false }
+        switch newItem.kind {
+        case .text, .richText:
+            return newItem.text == existing.text
+        case .url:
+            return newItem.urlMeta?.urlString == existing.urlMeta?.urlString
+        case .color:
+            return newItem.colorHex == existing.colorHex
+        case .file, .folder, .image:
+            return false
+        }
+    }
+
+    // MARK: - LRU eviction
+
+    /// Enforces `maxItems` and `maxStorageBytes`. Pinned items are spared.
+    /// Only runs if caps are exceeded.
+    private func evictIfNeeded() {
+        // 1. Count cap: drop oldest unpinned until under cap.
+        if activeBucket.items.count > settings.maxItems {
+            evictOldestUnpinned(toCount: settings.maxItems)
+        }
+        // 2. Size cap: quick heuristic — sum cached sidecar sizes from item metadata.
+        //    (Full on-disk audit lives in BucketStore and runs only on demand.)
+        let approxSize = activeBucket.items.reduce(Int64(0)) { acc, item in
+            acc + (item.fileRef?.byteSize ?? 0)
+        }
+        if approxSize > settings.maxStorageBytes {
+            evictOldestUnpinnedBySize(target: settings.maxStorageBytes)
+        }
+    }
+
+    private func evictOldestUnpinned(toCount maxCount: Int) {
+        // Items are newest-first; oldest at the tail.
+        var removed: [BucketItem] = []
+        while activeBucket.items.count > maxCount {
+            // Find last unpinned (oldest). If none, stop.
+            guard let lastUnpinnedIdx = activeBucket.items.lastIndex(where: { !$0.pinned }) else {
+                break
+            }
+            removed.append(activeBucket.items.remove(at: lastUnpinnedIdx))
+        }
+        if !removed.isEmpty {
+            cleanupSidecars(for: removed)
+        }
+    }
+
+    private func evictOldestUnpinnedBySize(target: Int64) {
+        var removed: [BucketItem] = []
+        var size = activeBucket.items.reduce(Int64(0)) { $0 + ($1.fileRef?.byteSize ?? 0) }
+        while size > target {
+            guard let idx = activeBucket.items.lastIndex(where: { !$0.pinned }) else { break }
+            let item = activeBucket.items.remove(at: idx)
+            size -= item.fileRef?.byteSize ?? 0
+            removed.append(item)
+        }
+        if !removed.isEmpty {
+            cleanupSidecars(for: removed)
+        }
+    }
+
+    private func cleanupSidecars(for items: [BucketItem]) {
+        let paths = items.compactMap { item -> String? in
+            [
+                item.fileRef?.cachedPath,
+                item.urlMeta?.faviconPath,
+                item.urlMeta?.ogImagePath,
+            ].compactMap { $0 }.joined(separator: "\n").isEmpty ? nil : nil
+        }
+        // The reduce above is noise; gather flat list explicitly:
+        var flat: [String] = []
+        for item in items {
+            if let p = item.fileRef?.cachedPath { flat.append(p) }
+            if let p = item.urlMeta?.faviconPath { flat.append(p) }
+            if let p = item.urlMeta?.ogImagePath { flat.append(p) }
+        }
+        _ = paths // silence unused warning; kept for future "returning removed paths" hook
+        guard !flat.isEmpty else { return }
+        Task { [store] in
+            await store.deleteSidecars(relativePaths: flat)
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func postChanged(change: BucketChangeKind, source: BucketChangeSource, itemID: UUID?) {
+        var info: [String: Any] = [
+            "change": change.rawValue,
+            "source": source.rawValue,
+        ]
+        if let itemID {
+            info["itemID"] = itemID
+        }
+        NotificationCenter.default.post(
+            name: .bucketChanged,
+            object: nil,
+            userInfo: info
+        )
+    }
+
+    // MARK: - Persist debounce
+
+    /// Coalesces rapid mutations into a single disk write every ~500 ms.
+    /// Mirrors the "debounced write" pattern the plan introduces for bucket
+    /// (CustomOhhManager writes synchronously — we don't, because adds arrive
+    /// every 500 ms from clipboard polling).
+    private func schedulePersist() {
+        persistDebounce?.cancel()
+        persistDebounce = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            let snapshot = self.activeBucket
+            self.persistInFlight = Task { [store] in
+                try? await store.saveBucket(snapshot)
+            }
+        }
+    }
+
+    /// Tests use this to deterministically flush pending debounced writes.
+    func flushForTests() async {
+        persistDebounce?.cancel()
+        let snapshot = activeBucket
+        try? await store.saveBucket(snapshot)
+        try? await store.saveSettings(settings)
+    }
+}

--- a/Sources/Core/BucketStore.swift
+++ b/Sources/Core/BucketStore.swift
@@ -17,7 +17,8 @@ import Foundation
 /// never blocks the UI thread.
 actor BucketStore {
 
-    let rootURL: URL
+    /// Sendable `let` — safe to read synchronously from any context.
+    nonisolated let rootURL: URL
 
     /// Default production root: `~/.snor-oh/buckets/`.
     /// Tests should inject a temp directory.

--- a/Sources/Core/BucketStore.swift
+++ b/Sources/Core/BucketStore.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// Owns on-disk state for the Bucket feature — manifest JSON + sidecar files.
+///
+/// Layout (v1, single-bucket; Epic 04 bumps to v2 schema):
+/// ```
+/// <rootURL>/
+/// ├── manifest.json          # Bucket JSON
+/// ├── settings.json          # BucketSettings JSON
+/// ├── files/<itemID>.<ext>   # dropped file copies
+/// ├── images/<itemID>.png    # screenshot + image copies
+/// ├── favicons/<itemID>.ico  # URL favicons
+/// └── og/<itemID>.jpg        # URL og:image
+/// ```
+///
+/// All disk I/O goes through this actor so the @MainActor `BucketManager`
+/// never blocks the UI thread.
+actor BucketStore {
+
+    let rootURL: URL
+
+    /// Default production root: `~/.snor-oh/buckets/`.
+    /// Tests should inject a temp directory.
+    init(rootURL: URL? = nil) {
+        if let rootURL {
+            self.rootURL = rootURL
+        } else {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            self.rootURL = home
+                .appendingPathComponent(".snor-oh")
+                .appendingPathComponent("buckets")
+        }
+    }
+
+    // MARK: - Manifest
+
+    /// Loads the persisted bucket. If no manifest exists, returns a fresh
+    /// empty `Bucket(name: "Default")` (caller decides whether to persist it).
+    func loadBucket() throws -> Bucket {
+        try ensureDirectories()
+        let url = manifestURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return Bucket(name: "Default")
+        }
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(Bucket.self, from: data)
+    }
+
+    /// Atomically persists the bucket.
+    func saveBucket(_ bucket: Bucket) throws {
+        try ensureDirectories()
+        let data = try encoder.encode(bucket)
+        try atomicWrite(data, to: manifestURL)
+    }
+
+    // MARK: - Settings
+
+    func loadSettings() throws -> BucketSettings {
+        try ensureDirectories()
+        let url = settingsURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return BucketSettings()
+        }
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(BucketSettings.self, from: data)
+    }
+
+    func saveSettings(_ settings: BucketSettings) throws {
+        try ensureDirectories()
+        let data = try encoder.encode(settings)
+        try atomicWrite(data, to: settingsURL)
+    }
+
+    // MARK: - Sidecars
+
+    /// Copies `source` into the bucket's sidecar directory under the given subdir
+    /// (e.g. `"files"`, `"images"`, `"favicons"`, `"og"`). Returns the path
+    /// relative to `rootURL` — that's what gets stored on `BucketItem.fileRef.cachedPath`.
+    ///
+    /// If `move: true`, the source is renamed (FS-rename); cross-volume moves
+    /// automatically fall back to copy+delete.
+    func copySidecar(
+        from source: URL,
+        itemID: UUID,
+        subdir: String,
+        ext: String? = nil,
+        move: Bool = false
+    ) throws -> String {
+        try ensureDirectories()
+        let subdirURL = rootURL.appendingPathComponent(subdir)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+
+        let resolvedExt = ext ?? source.pathExtension
+        let fileName = resolvedExt.isEmpty
+            ? itemID.uuidString
+            : "\(itemID.uuidString).\(resolvedExt)"
+        let dest = subdirURL.appendingPathComponent(fileName)
+
+        // If dest exists (crash recovery), remove it first — itemID is unique enough
+        // that we prefer the caller's new bytes.
+        try? FileManager.default.removeItem(at: dest)
+
+        if move {
+            do {
+                try FileManager.default.moveItem(at: source, to: dest)
+            } catch {
+                // Cross-volume or permission — fall back to copy+delete.
+                try FileManager.default.copyItem(at: source, to: dest)
+                try? FileManager.default.removeItem(at: source)
+            }
+        } else {
+            try FileManager.default.copyItem(at: source, to: dest)
+        }
+
+        return "\(subdir)/\(fileName)"
+    }
+
+    /// Writes raw bytes (e.g. clipboard image data) to a sidecar and returns the relative path.
+    func writeSidecar(
+        _ data: Data,
+        itemID: UUID,
+        subdir: String,
+        ext: String
+    ) throws -> String {
+        try ensureDirectories()
+        let subdirURL = rootURL.appendingPathComponent(subdir)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+
+        let fileName = "\(itemID.uuidString).\(ext)"
+        let dest = subdirURL.appendingPathComponent(fileName)
+        try atomicWrite(data, to: dest)
+        return "\(subdir)/\(fileName)"
+    }
+
+    /// Removes sidecar files for evicted items. Relative paths are resolved
+    /// against `rootURL`. Missing paths are ignored (idempotent).
+    func deleteSidecars(relativePaths: [String]) {
+        for rel in relativePaths {
+            let url = rootURL.appendingPathComponent(rel)
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Resolves a relative sidecar path back to an absolute URL.
+    nonisolated func absoluteURL(forRelative relativePath: String) -> URL {
+        rootURL.appendingPathComponent(relativePath)
+    }
+
+    /// Total sidecar storage on disk in bytes — used by BucketManager for
+    /// size-based LRU eviction.
+    func sidecarStorageBytes() -> Int64 {
+        let fm = FileManager.default
+        var total: Int64 = 0
+        let subdirs = ["files", "images", "favicons", "og"]
+        for sub in subdirs {
+            let subURL = rootURL.appendingPathComponent(sub)
+            guard let e = fm.enumerator(at: subURL, includingPropertiesForKeys: [.fileSizeKey]) else {
+                continue
+            }
+            for case let url as URL in e {
+                let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
+    // MARK: - Private
+
+    private var manifestURL: URL { rootURL.appendingPathComponent("manifest.json") }
+    private var settingsURL: URL { rootURL.appendingPathComponent("settings.json") }
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private func ensureDirectories() throws {
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    }
+
+    private func atomicWrite(_ data: Data, to url: URL) throws {
+        let tmp = url.appendingPathExtension("tmp")
+        try data.write(to: tmp, options: .atomic)
+        // replaceItemAt handles the case where `url` doesn't yet exist.
+        if FileManager.default.fileExists(atPath: url.path) {
+            _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+        } else {
+            try FileManager.default.moveItem(at: tmp, to: url)
+        }
+    }
+}

--- a/Sources/Core/BucketTypes.swift
+++ b/Sources/Core/BucketTypes.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+// MARK: - Kinds
+
+enum BucketItemKind: String, Codable, Sendable, CaseIterable {
+    case file
+    case folder
+    case image
+    case url
+    case text
+    case richText
+    case color
+}
+
+enum ScreenEdge: String, Codable, Sendable, CaseIterable {
+    case left
+    case right
+    case top
+    case bottom
+}
+
+// MARK: - Item
+
+struct BucketItem: Identifiable, Codable, Sendable, Hashable {
+    let id: UUID
+    var kind: BucketItemKind
+    var createdAt: Date
+    var lastAccessedAt: Date
+    var pinned: Bool
+
+    /// Real bundle ID (e.g. `com.apple.safari`) OR reserved sentinel
+    /// (`net.snor-oh.screenshot`, `net.snor-oh.peer:<uuid>`, etc.) per REVIEW.md §7.
+    var sourceBundleID: String?
+
+    /// Items dropped in the same drag session share this ID and render as one card.
+    var stackGroupID: UUID?
+
+    /// SHA-256 of the item's canonical bytes. Used for dedupe across clipboard,
+    /// screenshot, and peer-received items. Optional because plain text items
+    /// often rely on string-equality dedupe instead.
+    var contentHash: String?
+
+    // Payload — exactly one non-nil by contract. Not enforced at the type level
+    // to keep Codable simple; call sites that insert into BucketManager must
+    // respect the invariant.
+    var fileRef: FileRef?
+    var text: String?
+    var urlMeta: URLMetadata?
+    var colorHex: String?
+
+    struct FileRef: Codable, Sendable, Hashable {
+        var originalPath: String
+        /// Relative to the bucket storage directory. Nil until the sidecar copy lands.
+        var cachedPath: String?
+        var byteSize: Int64
+        var uti: String
+        var displayName: String
+    }
+
+    struct URLMetadata: Codable, Sendable, Hashable {
+        var urlString: String
+        var title: String?
+        /// Relative to the bucket storage directory.
+        var faviconPath: String?
+        /// Relative to the bucket storage directory.
+        var ogImagePath: String?
+    }
+
+    init(
+        id: UUID = UUID(),
+        kind: BucketItemKind,
+        createdAt: Date = Date(),
+        lastAccessedAt: Date? = nil,
+        pinned: Bool = false,
+        sourceBundleID: String? = nil,
+        stackGroupID: UUID? = nil,
+        contentHash: String? = nil,
+        fileRef: FileRef? = nil,
+        text: String? = nil,
+        urlMeta: URLMetadata? = nil,
+        colorHex: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.createdAt = createdAt
+        self.lastAccessedAt = lastAccessedAt ?? createdAt
+        self.pinned = pinned
+        self.sourceBundleID = sourceBundleID
+        self.stackGroupID = stackGroupID
+        self.contentHash = contentHash
+        self.fileRef = fileRef
+        self.text = text
+        self.urlMeta = urlMeta
+        self.colorHex = colorHex
+    }
+}
+
+// MARK: - Bucket
+
+struct Bucket: Identifiable, Codable, Sendable {
+    let id: UUID
+    var name: String
+    var items: [BucketItem]
+    var createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        name: String = "Default",
+        items: [BucketItem] = [],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.items = items
+        self.createdAt = createdAt
+    }
+}
+
+// MARK: - Settings
+
+struct BucketSettings: Codable, Sendable {
+    var maxItems: Int
+    var maxStorageBytes: Int64
+    var captureClipboard: Bool
+    var ignoredBundleIDs: Set<String>
+    var autoHideSeconds: Double
+    var preferredEdge: ScreenEdge
+    var hotkey: HotkeyBinding
+
+    init(
+        maxItems: Int = 200,
+        maxStorageBytes: Int64 = 100_000_000,
+        captureClipboard: Bool = true,
+        ignoredBundleIDs: Set<String> = [],
+        autoHideSeconds: Double = 2.0,
+        preferredEdge: ScreenEdge = .right,
+        hotkey: HotkeyBinding = HotkeyBinding(key: "B", modifiers: [.control, .option])
+    ) {
+        self.maxItems = maxItems
+        self.maxStorageBytes = maxStorageBytes
+        self.captureClipboard = captureClipboard
+        self.ignoredBundleIDs = ignoredBundleIDs
+        self.autoHideSeconds = autoHideSeconds
+        self.preferredEdge = preferredEdge
+        self.hotkey = hotkey
+    }
+
+    /// Forward-compatible decoding: any future field added here MUST have a default
+    /// so older on-disk JSON can still decode via this init.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.maxItems = try c.decodeIfPresent(Int.self, forKey: .maxItems) ?? 200
+        self.maxStorageBytes = try c.decodeIfPresent(Int64.self, forKey: .maxStorageBytes) ?? 100_000_000
+        self.captureClipboard = try c.decodeIfPresent(Bool.self, forKey: .captureClipboard) ?? true
+        self.ignoredBundleIDs = try c.decodeIfPresent(Set<String>.self, forKey: .ignoredBundleIDs) ?? []
+        self.autoHideSeconds = try c.decodeIfPresent(Double.self, forKey: .autoHideSeconds) ?? 2.0
+        self.preferredEdge = try c.decodeIfPresent(ScreenEdge.self, forKey: .preferredEdge) ?? .right
+        self.hotkey = try c.decodeIfPresent(HotkeyBinding.self, forKey: .hotkey)
+            ?? HotkeyBinding(key: "B", modifiers: [.control, .option])
+    }
+}
+
+// MARK: - Hotkey binding
+
+struct HotkeyBinding: Codable, Sendable, Hashable {
+    var key: String
+    var modifiers: Set<Modifier>
+
+    enum Modifier: String, Codable, Sendable, Hashable, CaseIterable {
+        case command
+        case option
+        case control
+        case shift
+    }
+}
+
+// MARK: - Bucket notification `source` sentinels
+
+/// Values for `.bucketChanged` `userInfo["source"]`. Kept as `String` on the
+/// notification itself for JSON-friendliness; this enum is the canonical
+/// writer side. Consumers (Epic 02 catch reaction, telemetry) compare as strings.
+enum BucketChangeSource: String, Sendable {
+    case panel
+    case mascot
+    case clipboard
+    case screenshot
+    case peer
+    case watchedFolder = "watched-folder"
+    case shortcut
+    case urlScheme = "url-scheme"
+}
+
+/// Values for `.bucketChanged` `userInfo["change"]`.
+enum BucketChangeKind: String, Sendable {
+    case added
+    case removed
+    case pinned
+    case unpinned
+    case cleared
+}

--- a/Sources/Core/ClipboardMonitor.swift
+++ b/Sources/Core/ClipboardMonitor.swift
@@ -22,6 +22,11 @@ final class ClipboardMonitor {
     private var lastChangeCount: Int = -1
     private let pasteboard: NSPasteboard = .general
 
+    /// Set this to `true` immediately before the app writes to the pasteboard
+    /// (e.g. "Copy as Plain Text" from a bucket card context menu). The next
+    /// tick will swallow the change, preventing a self-capture feedback loop.
+    var suppressNextCapture: Bool = false
+
     private init() {}
 
     // MARK: - Lifecycle
@@ -54,6 +59,13 @@ final class ClipboardMonitor {
         let current = pasteboard.changeCount
         guard current != lastChangeCount else { return }
         lastChangeCount = current
+
+        // Swallow writes we made ourselves (e.g. "Copy as Plain Text" in the
+        // bucket card context menu) — prevents a duplicate-capture loop.
+        if suppressNextCapture {
+            suppressNextCapture = false
+            return
+        }
 
         // Ignore list via frontmost app bundle ID.
         let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier

--- a/Sources/Core/ClipboardMonitor.swift
+++ b/Sources/Core/ClipboardMonitor.swift
@@ -1,0 +1,123 @@
+import Foundation
+import AppKit
+
+/// Polls `NSPasteboard.general.changeCount` every 500 ms and feeds new
+/// text / URL copies into `BucketManager.shared`.
+///
+/// Scoped to **text, URLs, and colors** in v1. File and image clipboard
+/// captures are out of scope here — Epic 03 owns screenshot auto-catch;
+/// file drag-in already works via `BucketDropHandler`.
+///
+/// Respects `BucketSettings.ignoredBundleIDs` — if the frontmost app's bundle
+/// ID is ignored, the capture is skipped.
+///
+/// Uses the CLAUDE.md-mandated timer pattern:
+/// `Timer(timeInterval:...)` + `RunLoop.main.add(t, forMode: .common)`.
+@MainActor
+final class ClipboardMonitor {
+
+    static let shared = ClipboardMonitor()
+
+    private var timer: Timer?
+    private var lastChangeCount: Int = -1
+    private let pasteboard: NSPasteboard = .general
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard timer == nil else { return }
+        // Seed: skip whatever's currently on the clipboard.
+        lastChangeCount = pasteboard.changeCount
+
+        let t = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.tick()
+            }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Tick
+
+    private func tick() {
+        let manager = BucketManager.shared
+        guard manager.settings.captureClipboard else { return }
+
+        let current = pasteboard.changeCount
+        guard current != lastChangeCount else { return }
+        lastChangeCount = current
+
+        // Ignore list via frontmost app bundle ID.
+        let frontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        if let frontmost, manager.settings.ignoredBundleIDs.contains(frontmost) {
+            return
+        }
+
+        guard let item = extractItem(sourceBundleID: frontmost) else { return }
+        manager.add(item, source: .clipboard)
+    }
+
+    // MARK: - Pasteboard → BucketItem
+
+    private func extractItem(sourceBundleID: String?) -> BucketItem? {
+        // Priority: URL > rich text (RTF) > plain text > color
+        if let urlString = readURL() {
+            return BucketItem(
+                kind: .url,
+                sourceBundleID: sourceBundleID,
+                urlMeta: .init(urlString: urlString, title: nil)
+            )
+        }
+        if let rtf = pasteboard.data(forType: .rtf) {
+            return BucketItem(
+                kind: .richText,
+                sourceBundleID: sourceBundleID,
+                text: rtf.base64EncodedString()
+            )
+        }
+        if let text = pasteboard.string(forType: .string), !text.isEmpty {
+            return BucketItem(
+                kind: .text,
+                sourceBundleID: sourceBundleID,
+                text: text
+            )
+        }
+        if let color = readColor() {
+            return BucketItem(
+                kind: .color,
+                sourceBundleID: sourceBundleID,
+                colorHex: color
+            )
+        }
+        return nil
+    }
+
+    private func readURL() -> String? {
+        // NSPasteboard.readObjects(forClasses: [NSURL.self])
+        if let objs = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL],
+           let first = objs.first, !first.isFileURL {
+            return first.absoluteString
+        }
+        return nil
+    }
+
+    private func readColor() -> String? {
+        if let objs = pasteboard.readObjects(forClasses: [NSColor.self], options: nil) as? [NSColor],
+           let color = objs.first {
+            let rgb = color.usingColorSpace(.sRGB) ?? color
+            let r = Int(round(rgb.redComponent * 255))
+            let g = Int(round(rgb.greenComponent * 255))
+            let b = Int(round(rgb.blueComponent * 255))
+            return String(format: "#%02X%02X%02X", r, g, b)
+        }
+        return nil
+    }
+}

--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -12,6 +12,14 @@ extension Notification.Name {
     static let visitorArrived = Notification.Name("visitorArrived")
     static let visitorLeft = Notification.Name("visitorLeft")
     static let discoveryHint = Notification.Name("discoveryHint")
+
+    /// Posted by `BucketManager` on every item add/remove/pin/clear.
+    /// `userInfo`:
+    ///   - `"source": String` — see `BucketChangeSource`
+    ///   - `"change": String` — see `BucketChangeKind`
+    ///   - `"itemID": UUID?` — nil on bulk changes like `.cleared`
+    /// Contract source: docs/prd/bucket/REVIEW.md §6.
+    static let bucketChanged = Notification.Name("bucketChanged")
 }
 
 // MARK: - SessionManager

--- a/Sources/Core/URLMetadataFetcher.swift
+++ b/Sources/Core/URLMetadataFetcher.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Best-effort OpenGraph + title + favicon extractor for bucketed URLs.
+///
+/// Runs a single HTTP GET with a 3 s timeout, reads at most 64 KB of the body,
+/// and pulls:
+///   - `<title>…</title>`
+///   - `<meta property="og:image" content="…">`
+///   - `<link rel="icon" href="…">`
+///
+/// Returns `nil` on any failure (no network, 4xx, 5xx, bad HTML, timeout). This
+/// is a polish feature — the URL item is fully usable without it.
+enum URLMetadataFetcher {
+
+    private static let maxBodyBytes = 64 * 1024
+    private static let timeoutSecs: TimeInterval = 3
+
+    static func fetch(_ urlString: String) async -> BucketItem.URLMetadata? {
+        guard let url = URL(string: urlString) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeoutSecs
+        request.setValue(
+            "Mozilla/5.0 snor-oh Bucket; +https://github.com/thanh-dong/snor-oh",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            let prefix = data.prefix(maxBodyBytes)
+            let html = String(data: prefix, encoding: .utf8)
+                ?? String(data: prefix, encoding: .isoLatin1)
+                ?? ""
+
+            let title = extractTitle(from: html)
+            let ogImage = extractOGImage(from: html, base: url)
+            let favicon = extractFavicon(from: html, base: url)
+
+            return .init(
+                urlString: urlString,
+                title: title,
+                faviconPath: favicon?.absoluteString,  // stored as absolute URL; caller may
+                ogImagePath: ogImage?.absoluteString   // download + cache separately.
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Regex extractors (deliberately tiny — no HTML parser dep)
+
+    private static func extractTitle(from html: String) -> String? {
+        guard let range = html.range(of: "<title[^>]*>([\\s\\S]*?)</title>",
+                                     options: [.regularExpression, .caseInsensitive]) else {
+            return nil
+        }
+        let slice = String(html[range])
+        // Strip tags + whitespace
+        let inner = slice
+            .replacingOccurrences(of: "<title[^>]*>", with: "", options: [.regularExpression, .caseInsensitive])
+            .replacingOccurrences(of: "</title>", with: "", options: [.regularExpression, .caseInsensitive])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let decoded = decodeHTMLEntities(inner)
+        return decoded.isEmpty ? nil : decoded
+    }
+
+    private static func extractOGImage(from html: String, base: URL) -> URL? {
+        return extractMeta(property: "og:image", from: html)
+            .flatMap { URL(string: $0, relativeTo: base) }
+    }
+
+    private static func extractFavicon(from html: String, base: URL) -> URL? {
+        // <link rel="icon" href="…"> or rel="shortcut icon"
+        let pattern = "<link[^>]+rel=[\"']([^\"']*icon[^\"']*)[\"'][^>]*href=[\"']([^\"']+)[\"']"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return base.scheme.flatMap { URL(string: "\($0)://\(base.host ?? "")/favicon.ico") }
+        }
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        if let match = regex.firstMatch(in: html, options: [], range: range),
+           match.numberOfRanges >= 3,
+           let hrefRange = Range(match.range(at: 2), in: html) {
+            return URL(string: String(html[hrefRange]), relativeTo: base)
+        }
+        // Fallback to /favicon.ico
+        if let scheme = base.scheme, let host = base.host {
+            return URL(string: "\(scheme)://\(host)/favicon.ico")
+        }
+        return nil
+    }
+
+    private static func extractMeta(property: String, from html: String) -> String? {
+        let pattern = "<meta[^>]+property=[\"']\(NSRegularExpression.escapedPattern(for: property))[\"'][^>]*content=[\"']([^\"']+)[\"']"
+        if let match = firstCapture(pattern: pattern, in: html) {
+            return decodeHTMLEntities(match)
+        }
+        // Try reversed attribute order
+        let reverse = "<meta[^>]+content=[\"']([^\"']+)[\"'][^>]*property=[\"']\(NSRegularExpression.escapedPattern(for: property))[\"']"
+        return firstCapture(pattern: reverse, in: html).map(decodeHTMLEntities)
+    }
+
+    private static func firstCapture(pattern: String, in html: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        guard let match = regex.firstMatch(in: html, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let captured = Range(match.range(at: 1), in: html) else {
+            return nil
+        }
+        return String(html[captured])
+    }
+
+    private static func decodeHTMLEntities(_ s: String) -> String {
+        s.replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+    }
+}

--- a/Sources/Util/Defaults.swift
+++ b/Sources/Util/Defaults.swift
@@ -20,6 +20,23 @@ enum DefaultsKey {
     static let devMode = "devMode"
     static let marketplaceURL = "marketplaceURL"
     static let creatorName = "creatorName"
+
+    // MARK: - Bucket feature (Epic 01)
+    /// Active panel tab — "sessions" or "bucket".
+    static let bucketActiveTab = "bucketActiveTab"
+    /// Whether clipboard capture is running. Mirrors `BucketSettings.captureClipboard`
+    /// for quick @AppStorage access from UI toggles.
+    static let bucketCaptureClipboard = "bucketCaptureClipboard"
+    /// Max items in the bucket (LRU eviction at this count).
+    static let bucketMaxItems = "bucketMaxItems"
+    /// Max total sidecar storage in MB (LRU eviction by size).
+    static let bucketMaxStorageMB = "bucketMaxStorageMB"
+    /// JSON-encoded `[String]` of ignored bundle IDs.
+    static let bucketIgnoredBundleIDs = "bucketIgnoredBundleIDs"
+    /// JSON-encoded `HotkeyBinding`.
+    static let bucketHotkey = "bucketHotkey"
+    /// One-time first-launch bubble gate.
+    static let bucketTipShown = "bucketTipShown"
 }
 
 enum DefaultsDefault {

--- a/Sources/Util/HotkeyRegistrar.swift
+++ b/Sources/Util/HotkeyRegistrar.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Carbon.HIToolbox
+import AppKit
+
+/// Registers global hotkeys via Carbon `RegisterEventHotKey`.
+///
+/// Scope: a single bucket-toggle hotkey for Epic 01. Later epics (04, 06)
+/// will register additional hotkeys through a new `register(id:binding:callback:)`
+/// overload — kept as TODO below to avoid over-engineering.
+@MainActor
+final class HotkeyRegistrar {
+
+    static let shared = HotkeyRegistrar()
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var handler: EventHandlerRef?
+    private var callback: (() -> Void)?
+
+    private init() {}
+
+    // MARK: - Public
+
+    /// Re-registers the hotkey. Safe to call repeatedly on settings change.
+    /// No-op if the binding has no resolvable key code.
+    func registerBucketToggle(binding: HotkeyBinding, callback: @escaping () -> Void) {
+        unregister()
+        guard let keyCode = Self.keyCode(for: binding.key) else {
+            NSLog("[hotkey] unsupported key: \(binding.key)")
+            return
+        }
+        let carbonMods = Self.carbonModifiers(from: binding.modifiers)
+
+        installHandlerIfNeeded()
+
+        var ref: EventHotKeyRef?
+        let hotKeyID = EventHotKeyID(signature: Self.signature, id: 1)
+        let status = RegisterEventHotKey(
+            UInt32(keyCode),
+            carbonMods,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &ref
+        )
+        guard status == noErr, let ref else {
+            NSLog("[hotkey] RegisterEventHotKey failed: \(status)")
+            return
+        }
+        self.hotKeyRef = ref
+        self.callback = callback
+    }
+
+    func unregister() {
+        if let ref = hotKeyRef {
+            UnregisterEventHotKey(ref)
+            hotKeyRef = nil
+        }
+        callback = nil
+    }
+
+    // MARK: - Private: event handler installation
+
+    private func installHandlerIfNeeded() {
+        guard handler == nil else { return }
+
+        var spec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let userData = Unmanaged.passUnretained(self).toOpaque()
+        let handlerProc: EventHandlerUPP = { _, eventRef, userData in
+            guard let userData, let eventRef else { return noErr }
+            let me = Unmanaged<HotkeyRegistrar>.fromOpaque(userData).takeUnretainedValue()
+
+            // Read the hot-key ID from the event and verify it's ours.
+            var hkID = EventHotKeyID()
+            let gotID = GetEventParameter(
+                eventRef,
+                UInt32(kEventParamDirectObject),
+                UInt32(typeEventHotKeyID),
+                nil,
+                MemoryLayout<EventHotKeyID>.size,
+                nil,
+                &hkID
+            )
+            guard gotID == noErr, hkID.signature == HotkeyRegistrar.signature else {
+                return noErr
+            }
+
+            DispatchQueue.main.async {
+                me.callback?()
+            }
+            return noErr
+        }
+
+        var outHandler: EventHandlerRef?
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            handlerProc,
+            1,
+            &spec,
+            userData,
+            &outHandler
+        )
+        self.handler = outHandler
+    }
+
+    // MARK: - Private: key + modifier mapping
+
+    private static let signature: OSType = {
+        let chars = Array("SNOH".utf8)
+        return (OSType(chars[0]) << 24)
+            | (OSType(chars[1]) << 16)
+            | (OSType(chars[2]) << 8)
+            | OSType(chars[3])
+    }()
+
+    /// Minimal key-code table. Letters A–Z + digits 0–9 covers the full default
+    /// bucket binding (⌃⌥B). Extend as needed if more keys become user-rebindable.
+    private static let keyCodes: [String: Int] = [
+        "A": kVK_ANSI_A, "B": kVK_ANSI_B, "C": kVK_ANSI_C, "D": kVK_ANSI_D,
+        "E": kVK_ANSI_E, "F": kVK_ANSI_F, "G": kVK_ANSI_G, "H": kVK_ANSI_H,
+        "I": kVK_ANSI_I, "J": kVK_ANSI_J, "K": kVK_ANSI_K, "L": kVK_ANSI_L,
+        "M": kVK_ANSI_M, "N": kVK_ANSI_N, "O": kVK_ANSI_O, "P": kVK_ANSI_P,
+        "Q": kVK_ANSI_Q, "R": kVK_ANSI_R, "S": kVK_ANSI_S, "T": kVK_ANSI_T,
+        "U": kVK_ANSI_U, "V": kVK_ANSI_V, "W": kVK_ANSI_W, "X": kVK_ANSI_X,
+        "Y": kVK_ANSI_Y, "Z": kVK_ANSI_Z,
+        "0": kVK_ANSI_0, "1": kVK_ANSI_1, "2": kVK_ANSI_2, "3": kVK_ANSI_3,
+        "4": kVK_ANSI_4, "5": kVK_ANSI_5, "6": kVK_ANSI_6, "7": kVK_ANSI_7,
+        "8": kVK_ANSI_8, "9": kVK_ANSI_9,
+    ]
+
+    static func keyCode(for key: String) -> Int? {
+        keyCodes[key.uppercased()]
+    }
+
+    static func carbonModifiers(from mods: Set<HotkeyBinding.Modifier>) -> UInt32 {
+        var out: UInt32 = 0
+        if mods.contains(.command) { out |= UInt32(cmdKey) }
+        if mods.contains(.option)  { out |= UInt32(optionKey) }
+        if mods.contains(.control) { out |= UInt32(controlKey) }
+        if mods.contains(.shift)   { out |= UInt32(shiftKey) }
+        return out
+    }
+}

--- a/Sources/Util/QuickLookPreviewer.swift
+++ b/Sources/Util/QuickLookPreviewer.swift
@@ -10,17 +10,20 @@ import Quartz
 ///   2. First-responder handoff for `QLPreviewPanelController` is awkward from
 ///      SwiftUI. We bypass it: set the data source directly and call
 ///      `makeKeyAndOrderFront(_:)`.
-@MainActor
 final class QuickLookPreviewer: NSObject, QLPreviewPanelDataSource {
 
     static let shared = QuickLookPreviewer()
 
+    /// Only touched from the main queue (both the `show(url:)` call site and
+    /// `QLPreviewPanel` callbacks run on main). Marked nonisolated so the
+    /// protocol conformance doesn't trip Swift 6 isolation checks.
     private var url: URL?
 
     private override init() {
         super.init()
     }
 
+    @MainActor
     func show(url: URL) {
         self.url = url
         guard let panel = QLPreviewPanel.shared() else { return }
@@ -30,6 +33,7 @@ final class QuickLookPreviewer: NSObject, QLPreviewPanelDataSource {
     }
 
     // MARK: - QLPreviewPanelDataSource
+    // QLPreviewPanel dispatches to its data source on the main queue.
 
     func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
         url != nil ? 1 : 0

--- a/Sources/Util/QuickLookPreviewer.swift
+++ b/Sources/Util/QuickLookPreviewer.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Quartz
+
+/// Singleton helper that fronts `QLPreviewPanel.shared()` for the Bucket UI.
+///
+/// Works around two annoyances:
+///   1. `QLPreviewPanel` is a shared panel that requires a data source on every
+///      show — a stateless call site (`QuickLookPreviewer.shared.show(url:)`)
+///      is simpler than wiring a dedicated data-source object per view.
+///   2. First-responder handoff for `QLPreviewPanelController` is awkward from
+///      SwiftUI. We bypass it: set the data source directly and call
+///      `makeKeyAndOrderFront(_:)`.
+@MainActor
+final class QuickLookPreviewer: NSObject, QLPreviewPanelDataSource {
+
+    static let shared = QuickLookPreviewer()
+
+    private var url: URL?
+
+    private override init() {
+        super.init()
+    }
+
+    func show(url: URL) {
+        self.url = url
+        guard let panel = QLPreviewPanel.shared() else { return }
+        panel.dataSource = self
+        panel.reloadData()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    // MARK: - QLPreviewPanelDataSource
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        url != nil ? 1 : 0
+    }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> any QLPreviewItem {
+        (url ?? URL(fileURLWithPath: "/")) as NSURL
+    }
+}

--- a/Sources/Views/BucketCardView.swift
+++ b/Sources/Views/BucketCardView.swift
@@ -89,6 +89,39 @@ struct BucketCardView: View {
             itemProviderForDrag()
         }
         .contextMenu { contextMenu }
+        .focusable()
+        .onKeyPress(.space) {
+            if let url = quickLookURL() {
+                QuickLookPreviewer.shared.show(url: url)
+                return .handled
+            }
+            return .ignored
+        }
+    }
+
+    /// URL a Quick Look panel can display for this item. Only files and cached
+    /// images qualify — text / URL / color items return nil (spacebar becomes
+    /// a no-op).
+    private func quickLookURL() -> URL? {
+        switch item.kind {
+        case .file, .folder:
+            if let path = item.fileRef?.originalPath,
+               !path.isEmpty,
+               FileManager.default.fileExists(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+            if let rel = item.fileRef?.cachedPath {
+                return storeRootURL.appendingPathComponent(rel)
+            }
+            return nil
+        case .image:
+            if let rel = item.fileRef?.cachedPath {
+                return storeRootURL.appendingPathComponent(rel)
+            }
+            return nil
+        case .url, .text, .richText, .color:
+            return nil
+        }
     }
 
     // MARK: - Context menu
@@ -100,6 +133,7 @@ struct BucketCardView: View {
         }
         if let plain = plainTextPayload {
             Button("Copy as Plain Text") {
+                ClipboardMonitor.shared.suppressNextCapture = true
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(plain, forType: .string)
             }

--- a/Sources/Views/BucketCardView.swift
+++ b/Sources/Views/BucketCardView.swift
@@ -1,0 +1,294 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Renders a single `BucketItem` as a compact card inside the bucket grid.
+///
+/// Per-kind visuals:
+///   - `.file` / `.folder`: icon + name + size
+///   - `.image`: thumbnail + kind chip
+///   - `.url`: favicon + title + host
+///   - `.text` / `.richText`: truncated text excerpt
+///   - `.color`: swatch + hex string
+///
+/// Interactions:
+///   - Hover reveals pin + delete buttons.
+///   - Click pins (toggle).
+///   - Drag-out provides an `NSItemProvider` of the right type (file URL / URL /
+///     plain text / image / RTF).
+///   - Right-click menu: Pin/Unpin, Copy as plain text, Remove.
+struct BucketCardView: View {
+
+    let item: BucketItem
+    let storeRootURL: URL
+    let manager: BucketManager
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            thumbnail
+                .frame(width: 32, height: 32)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(primaryLine)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+                if let sub = secondaryLine {
+                    Text(sub)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if hovering {
+                HStack(spacing: 4) {
+                    Button {
+                        manager.togglePin(id: item.id)
+                    } label: {
+                        Image(systemName: item.pinned ? "pin.fill" : "pin")
+                            .font(.system(size: 10))
+                            .foregroundStyle(item.pinned ? .orange : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(item.pinned ? "Unpin" : "Pin")
+
+                    Button {
+                        manager.remove(id: item.id)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Remove")
+                }
+            } else if item.pinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.orange.opacity(0.7))
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(hovering ? Color.primary.opacity(0.08) : Color.primary.opacity(0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+        .onHover { hovering = $0 }
+        .onDrag {
+            itemProviderForDrag()
+        }
+        .contextMenu { contextMenu }
+    }
+
+    // MARK: - Context menu
+
+    @ViewBuilder
+    private var contextMenu: some View {
+        Button(item.pinned ? "Unpin" : "Pin") {
+            manager.togglePin(id: item.id)
+        }
+        if let plain = plainTextPayload {
+            Button("Copy as Plain Text") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(plain, forType: .string)
+            }
+        }
+        if let url = item.urlMeta?.urlString, let _ = URL(string: url) {
+            Button("Open URL") {
+                if let u = URL(string: url) { NSWorkspace.shared.open(u) }
+            }
+        }
+        if item.kind == .file || item.kind == .folder,
+           let path = item.fileRef?.originalPath, !path.isEmpty {
+            Button("Reveal in Finder") {
+                NSWorkspace.shared.selectFile(path, inFileViewerRootedAtPath: "")
+            }
+        }
+        Divider()
+        Button("Remove") { manager.remove(id: item.id) }
+    }
+
+    // MARK: - Drag-out provider
+
+    private func itemProviderForDrag() -> NSItemProvider {
+        switch item.kind {
+        case .file, .folder:
+            if let path = item.fileRef?.originalPath, !path.isEmpty {
+                let url = URL(fileURLWithPath: path)
+                return NSItemProvider(object: url as NSURL)
+            }
+            return NSItemProvider()
+        case .url:
+            if let s = item.urlMeta?.urlString, let url = URL(string: s) {
+                return NSItemProvider(object: url as NSURL)
+            }
+            return NSItemProvider()
+        case .image:
+            if let rel = item.fileRef?.cachedPath {
+                let abs = storeRootURL.appendingPathComponent(rel)
+                return NSItemProvider(object: abs as NSURL)
+            }
+            return NSItemProvider()
+        case .text:
+            return NSItemProvider(object: (item.text ?? "") as NSString)
+        case .richText:
+            if let s = item.text, let rtf = Data(base64Encoded: s) {
+                let provider = NSItemProvider()
+                provider.registerDataRepresentation(
+                    forTypeIdentifier: UTType.rtf.identifier, visibility: .all
+                ) { completion in
+                    completion(rtf, nil)
+                    return nil
+                }
+                return provider
+            }
+            return NSItemProvider(object: (item.text ?? "") as NSString)
+        case .color:
+            return NSItemProvider(object: (item.colorHex ?? "") as NSString)
+        }
+    }
+
+    // MARK: - Thumbnail
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        switch item.kind {
+        case .image:
+            if let rel = item.fileRef?.cachedPath,
+               let nsImage = NSImage(contentsOf: storeRootURL.appendingPathComponent(rel)) {
+                Image(nsImage: nsImage).resizable().scaledToFill()
+            } else {
+                Image(systemName: "photo").foregroundStyle(.secondary)
+            }
+        case .file:
+            fileIconView
+        case .folder:
+            Image(systemName: "folder.fill")
+                .font(.system(size: 22))
+                .foregroundStyle(.blue)
+        case .url:
+            Image(systemName: "link")
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+        case .text, .richText:
+            Image(systemName: "text.alignleft")
+                .font(.system(size: 18))
+                .foregroundStyle(.secondary)
+        case .color:
+            let hex = item.colorHex ?? "#999999"
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color(hex: hex) ?? .gray)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    @ViewBuilder
+    private var fileIconView: some View {
+        if let path = item.fileRef?.originalPath, !path.isEmpty,
+           FileManager.default.fileExists(atPath: path) {
+            let icon = NSWorkspace.shared.icon(forFile: path)
+            Image(nsImage: icon).resizable().scaledToFit()
+        } else {
+            Image(systemName: "doc")
+                .font(.system(size: 20))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Text content
+
+    private var primaryLine: String {
+        switch item.kind {
+        case .file, .folder, .image:
+            return item.fileRef?.displayName ?? "Untitled"
+        case .url:
+            return item.urlMeta?.title ?? item.urlMeta?.urlString ?? "Link"
+        case .text, .richText:
+            let s = plainTextPayload ?? ""
+            return s.split(separator: "\n").first.map(String.init) ?? s
+        case .color:
+            return item.colorHex ?? "#000000"
+        }
+    }
+
+    private var secondaryLine: String? {
+        switch item.kind {
+        case .file, .image:
+            return item.fileRef.flatMap { formatSize($0.byteSize) }
+        case .folder:
+            return "Folder"
+        case .url:
+            if let host = item.urlMeta.flatMap({ URL(string: $0.urlString)?.host }) { return host }
+            return item.urlMeta?.urlString
+        case .text:
+            let count = (plainTextPayload ?? "").count
+            return "\(count) chars"
+        case .richText:
+            return "Rich text"
+        case .color:
+            return nil
+        }
+    }
+
+    private var plainTextPayload: String? {
+        switch item.kind {
+        case .text:
+            return item.text
+        case .richText:
+            // RTF → plain text for display / copy-out
+            if let s = item.text, let data = Data(base64Encoded: s),
+               let attr = try? NSAttributedString(
+                   data: data,
+                   options: [.documentType: NSAttributedString.DocumentType.rtf],
+                   documentAttributes: nil
+               ) {
+                return attr.string
+            }
+            return item.text
+        default:
+            return nil
+        }
+    }
+
+    private func formatSize(_ bytes: Int64) -> String {
+        let fmt = ByteCountFormatter()
+        fmt.allowedUnits = [.useKB, .useMB, .useGB]
+        fmt.countStyle = .file
+        return fmt.string(fromByteCount: bytes)
+    }
+}
+
+// MARK: - Color(hex:) helper
+
+extension Color {
+    init?(hex: String) {
+        var s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6 || s.count == 8,
+              let v = UInt64(s, radix: 16) else { return nil }
+        let r, g, b, a: Double
+        if s.count == 8 {
+            a = Double((v >> 24) & 0xFF) / 255.0
+            r = Double((v >> 16) & 0xFF) / 255.0
+            g = Double((v >> 8) & 0xFF) / 255.0
+            b = Double(v & 0xFF) / 255.0
+        } else {
+            a = 1.0
+            r = Double((v >> 16) & 0xFF) / 255.0
+            g = Double((v >> 8) & 0xFF) / 255.0
+            b = Double(v & 0xFF) / 255.0
+        }
+        self = Color(.sRGB, red: r, green: g, blue: b, opacity: a)
+    }
+}

--- a/Sources/Views/BucketView.swift
+++ b/Sources/Views/BucketView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Main bucket UI — search field + scrollable item list + toolbar.
+///
+/// Hosted inside `SnorOhPanelView` as the alternate tab. Accepts drops through
+/// `BucketDropHandler` with `source = .panel`.
+struct BucketView: View {
+
+    let manager: BucketManager
+    let storeRootURL: URL
+
+    @State private var query: String = ""
+    @State private var dropTargeted = false
+
+    private var visibleItems: [BucketItem] {
+        query.isEmpty ? manager.activeBucket.items : manager.search(query)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+
+            Divider().opacity(0.2)
+
+            content
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(dropTargeted ? Color.accentColor.opacity(0.12) : .clear)
+                )
+                .animation(.easeOut(duration: 0.15), value: dropTargeted)
+                .onDrop(
+                    of: BucketDropHandler.supportedUTTypes,
+                    isTargeted: $dropTargeted
+                ) { providers in
+                    BucketDropHandler.ingest(providers: providers, source: .panel)
+                }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            TextField("Search…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Menu {
+                Button("Clear Unpinned", role: .destructive) {
+                    manager.clearUnpinned()
+                }
+                .disabled(manager.activeBucket.items.filter { !$0.pinned }.isEmpty)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if visibleItems.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 4) {
+                    ForEach(visibleItems) { item in
+                        BucketCardView(
+                            item: item,
+                            storeRootURL: storeRootURL,
+                            manager: manager
+                        )
+                    }
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 6)
+            }
+            .frame(maxHeight: 240)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.system(size: 22))
+                .foregroundStyle(.secondary)
+            Text(query.isEmpty ? "Drop anything here" : "No matches")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            if query.isEmpty {
+                Text("Files · URLs · images · text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 120)
+    }
+}

--- a/Sources/Views/MascotView.swift
+++ b/Sources/Views/MascotView.swift
@@ -34,6 +34,9 @@ struct MascotView: View {
             AnimatedSpriteView(engine: spriteEngine)
                 .frame(width: spriteSize, height: spriteSize)
                 .shadow(color: glowColor, radius: glowMode == "off" ? 0 : 12)
+                .onDrop(of: BucketDropHandler.supportedUTTypes, isTargeted: nil) { providers in
+                    BucketDropHandler.ingest(providers: providers, source: .mascot)
+                }
 
             // Status pill
             StatusPill(status: sessionManager.currentUI)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -35,22 +35,50 @@ struct SettingsView: View {
 struct BucketTab: View {
     let manager: BucketManager
 
-    @State private var captureClipboard: Bool = true
-    @State private var maxItems: Double = 200
-    @State private var maxStorageMB: Double = 100
     @State private var newIgnoreEntry: String = ""
+
+    /// All sliders/toggles bind directly to `manager.settings` via these
+    /// computed bindings so the UI stays in sync with any external mutation
+    /// (e.g. programmatic `updateSettings`, cross-window changes, disk reload).
+    private var captureClipboardBinding: Binding<Bool> {
+        Binding(
+            get: { manager.settings.captureClipboard },
+            set: { new in
+                var s = manager.settings
+                s.captureClipboard = new
+                manager.updateSettings(s)
+            }
+        )
+    }
+
+    private var maxItemsBinding: Binding<Double> {
+        Binding(
+            get: { Double(manager.settings.maxItems) },
+            set: { new in
+                var s = manager.settings
+                s.maxItems = Int(new)
+                manager.updateSettings(s)
+            }
+        )
+    }
+
+    private var maxStorageMBBinding: Binding<Double> {
+        Binding(
+            get: { Double(manager.settings.maxStorageBytes / 1_000_000) },
+            set: { new in
+                var s = manager.settings
+                s.maxStorageBytes = Int64(new) * 1_000_000
+                manager.updateSettings(s)
+            }
+        )
+    }
 
     var body: some View {
         Form {
             Section("Clipboard Capture") {
-                Toggle("Automatically capture clipboard", isOn: $captureClipboard)
-                    .onChange(of: captureClipboard) { _, new in
-                        var s = manager.settings
-                        s.captureClipboard = new
-                        manager.updateSettings(s)
-                    }
+                Toggle("Automatically capture clipboard", isOn: captureClipboardBinding)
 
-                if captureClipboard {
+                if manager.settings.captureClipboard {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Ignored apps (bundle IDs)")
                             .font(.system(size: 11))
@@ -94,26 +122,16 @@ struct BucketTab: View {
             Section("Capacity") {
                 HStack {
                     Text("Max items")
-                    Slider(value: $maxItems, in: 50...1000, step: 50)
-                        .onChange(of: maxItems) { _, new in
-                            var s = manager.settings
-                            s.maxItems = Int(new)
-                            manager.updateSettings(s)
-                        }
-                    Text("\(Int(maxItems))")
+                    Slider(value: maxItemsBinding, in: 50...1000, step: 50)
+                    Text("\(manager.settings.maxItems)")
                         .monospacedDigit()
                         .frame(width: 44, alignment: .trailing)
                 }
 
                 HStack {
                     Text("Max storage")
-                    Slider(value: $maxStorageMB, in: 10...1000, step: 10)
-                        .onChange(of: maxStorageMB) { _, new in
-                            var s = manager.settings
-                            s.maxStorageBytes = Int64(new) * 1_000_000
-                            manager.updateSettings(s)
-                        }
-                    Text("\(Int(maxStorageMB)) MB")
+                    Slider(value: maxStorageMBBinding, in: 10...1000, step: 10)
+                    Text("\(manager.settings.maxStorageBytes / 1_000_000) MB")
                         .monospacedDigit()
                         .frame(width: 60, alignment: .trailing)
                 }
@@ -126,11 +144,6 @@ struct BucketTab: View {
             }
         }
         .formStyle(.grouped)
-        .onAppear {
-            captureClipboard = manager.settings.captureClipboard
-            maxItems = Double(manager.settings.maxItems)
-            maxStorageMB = Double(manager.settings.maxStorageBytes / 1_000_000)
-        }
     }
 }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -17,6 +17,9 @@ struct SettingsView: View {
             OhhTab(sessionManager: sessionManager, spriteEngine: spriteEngine)
                 .tabItem { Label("Ohh", systemImage: "pawprint") }
 
+            BucketTab(manager: BucketManager.shared)
+                .tabItem { Label("Bucket", systemImage: "tray.full") }
+
             ClaudeCodeTab()
                 .tabItem { Label("Claude Code", systemImage: "terminal") }
 
@@ -24,6 +27,110 @@ struct SettingsView: View {
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
         .frame(width: 520, height: 560)
+    }
+}
+
+// MARK: - Bucket Tab
+
+struct BucketTab: View {
+    let manager: BucketManager
+
+    @State private var captureClipboard: Bool = true
+    @State private var maxItems: Double = 200
+    @State private var maxStorageMB: Double = 100
+    @State private var newIgnoreEntry: String = ""
+
+    var body: some View {
+        Form {
+            Section("Clipboard Capture") {
+                Toggle("Automatically capture clipboard", isOn: $captureClipboard)
+                    .onChange(of: captureClipboard) { _, new in
+                        var s = manager.settings
+                        s.captureClipboard = new
+                        manager.updateSettings(s)
+                    }
+
+                if captureClipboard {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Ignored apps (bundle IDs)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+
+                        ForEach(Array(manager.settings.ignoredBundleIDs).sorted(), id: \.self) { bid in
+                            HStack {
+                                Text(bid)
+                                    .font(.system(size: 11, design: .monospaced))
+                                Spacer()
+                                Button {
+                                    var s = manager.settings
+                                    s.ignoredBundleIDs.remove(bid)
+                                    manager.updateSettings(s)
+                                } label: {
+                                    Image(systemName: "minus.circle")
+                                        .foregroundStyle(.red)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+
+                        HStack {
+                            TextField("e.g. com.1password.1password", text: $newIgnoreEntry)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(size: 11, design: .monospaced))
+                            Button("Add") {
+                                let trimmed = newIgnoreEntry
+                                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                                guard !trimmed.isEmpty else { return }
+                                var s = manager.settings
+                                s.ignoredBundleIDs.insert(trimmed)
+                                manager.updateSettings(s)
+                                newIgnoreEntry = ""
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section("Capacity") {
+                HStack {
+                    Text("Max items")
+                    Slider(value: $maxItems, in: 50...1000, step: 50)
+                        .onChange(of: maxItems) { _, new in
+                            var s = manager.settings
+                            s.maxItems = Int(new)
+                            manager.updateSettings(s)
+                        }
+                    Text("\(Int(maxItems))")
+                        .monospacedDigit()
+                        .frame(width: 44, alignment: .trailing)
+                }
+
+                HStack {
+                    Text("Max storage")
+                    Slider(value: $maxStorageMB, in: 10...1000, step: 10)
+                        .onChange(of: maxStorageMB) { _, new in
+                            var s = manager.settings
+                            s.maxStorageBytes = Int64(new) * 1_000_000
+                            manager.updateSettings(s)
+                        }
+                    Text("\(Int(maxStorageMB)) MB")
+                        .monospacedDigit()
+                        .frame(width: 60, alignment: .trailing)
+                }
+            }
+
+            Section("Hotkey") {
+                Text("Press **⌃⌥B** to toggle the bucket panel.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear {
+            captureClipboard = manager.settings.captureClipboard
+            maxItems = Double(manager.settings.maxItems)
+            maxStorageMB = Double(manager.settings.maxStorageBytes / 1_000_000)
+        }
     }
 }
 

--- a/Sources/Views/SnorOhPanelView.swift
+++ b/Sources/Views/SnorOhPanelView.swift
@@ -63,6 +63,7 @@ struct SnorOhPanelView: View {
     let spriteEngine: SpriteEngine
     let bubbleManager: BubbleManager
     let visitManager: VisitManager?
+    let bucketManager: BucketManager
     @State private var messagePeer: PeerInfo?
     @State private var messageText = ""
 
@@ -71,6 +72,7 @@ struct SnorOhPanelView: View {
     @AppStorage(DefaultsKey.theme) private var theme = "dark"
     @AppStorage(DefaultsKey.displayScale) private var displayScale = 1.0
     @AppStorage(DefaultsKey.glowMode) private var glowMode = "off"
+    @AppStorage(DefaultsKey.bucketActiveTab) private var activeTab = "sessions"
     @Environment(\.colorScheme) private var colorScheme
 
     private var size: SnorOhSize {
@@ -109,7 +111,15 @@ struct SnorOhPanelView: View {
                 speechBubble
             }
 
-            sessionArea
+            tabSwitcher
+
+            if activeTab == "bucket" {
+                BucketView(manager: bucketManager, storeRootURL: bucketManager.storeRootURL)
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 4)
+            } else {
+                sessionArea
+            }
         }
         .frame(width: size.panelWidth)
         .onAppear {
@@ -118,6 +128,47 @@ struct SnorOhPanelView: View {
         }
         .onChange(of: sessionManager.currentUI) { _, s in spriteEngine.setStatus(s) }
         .onChange(of: sessionManager.pet) { _, p in spriteEngine.setPet(p) }
+    }
+
+    // MARK: - Tab Switcher
+
+    private var tabSwitcher: some View {
+        HStack(spacing: 4) {
+            tabButton(title: "Sessions", value: "sessions")
+            tabButton(
+                title: bucketManager.activeBucket.items.isEmpty
+                    ? "Bucket"
+                    : "Bucket (\(bucketManager.activeBucket.items.count))",
+                value: "bucket"
+            )
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 4)
+    }
+
+    private func tabButton(title: String, value: String) -> some View {
+        let selected = activeTab == value
+        return Button {
+            withAnimation(.easeOut(duration: 0.15)) { activeTab = value }
+        } label: {
+            Text(title)
+                .font(.system(size: size.metaFont, weight: selected ? .semibold : .regular))
+                .foregroundStyle(
+                    selected
+                        ? (isDark ? Color.white : Color.black)
+                        : (isDark ? Color.white.opacity(0.45) : Color.black.opacity(0.4))
+                )
+                .padding(.vertical, 3)
+                .padding(.horizontal, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(selected
+                            ? (isDark ? Color.white.opacity(0.1) : Color.black.opacity(0.08))
+                            : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Mascot Stage
@@ -135,6 +186,9 @@ struct SnorOhPanelView: View {
         .frame(maxWidth: .infinity)
         .frame(height: spriteSize + (glowRadius > 0 ? 20 : 8))
         .padding(.top, 4)
+        .onDrop(of: BucketDropHandler.supportedUTTypes, isTargeted: nil) { providers in
+            BucketDropHandler.ingest(providers: providers, source: .mascot)
+        }
         .contextMenu { mascotContextMenu }
         .sheet(item: $messagePeer) { peer in
             SendMessageSheet(

--- a/Sources/Views/SnorOhPanelWindow.swift
+++ b/Sources/Views/SnorOhPanelWindow.swift
@@ -40,7 +40,8 @@ final class SnorOhPanelWindow: NSPanel {
             sessionManager: sessionManager,
             spriteEngine: spriteEngine,
             bubbleManager: bubbleManager,
-            visitManager: visitManager
+            visitManager: visitManager,
+            bucketManager: BucketManager.shared
         )
         let hostingView = NSHostingView(rootView: panelView)
         hostingView.sizingOptions = [.minSize, .intrinsicContentSize]

--- a/Tests/BucketManagerTests.swift
+++ b/Tests/BucketManagerTests.swift
@@ -1,0 +1,223 @@
+import XCTest
+@testable import SnorOhSwift
+
+@MainActor
+final class BucketManagerTests: XCTestCase {
+
+    var tempRoot: URL!
+    var manager: BucketManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bucket-mgr-test-\(UUID().uuidString)")
+        let store = BucketStore(rootURL: tempRoot)
+        manager = BucketManager(store: store)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+        try await super.tearDown()
+    }
+
+    // MARK: - add / remove / pin / clear
+
+    func testAddInsertsAtHead() {
+        let a = BucketItem(kind: .text, text: "first")
+        let b = BucketItem(kind: .text, text: "second")
+        manager.add(a, source: .panel)
+        manager.add(b, source: .panel)
+        XCTAssertEqual(manager.activeBucket.items.count, 2)
+        XCTAssertEqual(manager.activeBucket.items.first?.text, "second")
+    }
+
+    func testAddPostsBucketChangedWithSource() {
+        let exp = expectation(forNotification: .bucketChanged, object: nil) { note in
+            let info = note.userInfo ?? [:]
+            return info["source"] as? String == "clipboard"
+                && info["change"] as? String == "added"
+        }
+        manager.add(BucketItem(kind: .text, text: "x"), source: .clipboard)
+        wait(for: [exp], timeout: 0.2)
+    }
+
+    func testRemoveByID() {
+        let item = BucketItem(kind: .text, text: "toremove")
+        manager.add(item, source: .panel)
+        manager.remove(id: item.id)
+        XCTAssertTrue(manager.activeBucket.items.isEmpty)
+    }
+
+    func testTogglePinFlipsFlag() {
+        let item = BucketItem(kind: .text, text: "x")
+        manager.add(item, source: .panel)
+        XCTAssertFalse(manager.activeBucket.items[0].pinned)
+        manager.togglePin(id: item.id)
+        XCTAssertTrue(manager.activeBucket.items[0].pinned)
+        manager.togglePin(id: item.id)
+        XCTAssertFalse(manager.activeBucket.items[0].pinned)
+    }
+
+    func testClearUnpinnedKeepsPinnedOnes() {
+        let a = BucketItem(kind: .text, text: "keep")
+        let b = BucketItem(kind: .text, text: "drop")
+        manager.add(a, source: .panel)
+        manager.add(b, source: .panel)
+        manager.togglePin(id: a.id)  // pin "keep"
+        manager.clearUnpinned()
+        XCTAssertEqual(manager.activeBucket.items.count, 1)
+        XCTAssertEqual(manager.activeBucket.items[0].text, "keep")
+    }
+
+    // MARK: - Clipboard dedupe
+
+    func testConsecutiveIdenticalTextDeduped() {
+        manager.add(BucketItem(kind: .text, text: "hello"), source: .clipboard)
+        manager.add(BucketItem(kind: .text, text: "hello"), source: .clipboard)
+        XCTAssertEqual(manager.activeBucket.items.count, 1)
+    }
+
+    func testDifferentKindsNotDeduped() {
+        manager.add(BucketItem(kind: .text, text: "abc"), source: .clipboard)
+        manager.add(BucketItem(kind: .color, colorHex: "abc"), source: .clipboard)
+        XCTAssertEqual(manager.activeBucket.items.count, 2)
+    }
+
+    func testNonAdjacentDuplicatesAllowed() {
+        manager.add(BucketItem(kind: .text, text: "a"), source: .clipboard)
+        manager.add(BucketItem(kind: .text, text: "b"), source: .clipboard)
+        manager.add(BucketItem(kind: .text, text: "a"), source: .clipboard) // allowed
+        XCTAssertEqual(manager.activeBucket.items.count, 3)
+    }
+
+    // MARK: - LRU by count
+
+    func testLRUEvictionByCount() {
+        var s = manager.settings
+        s.maxItems = 3
+        manager.updateSettings(s)
+
+        for i in 0..<5 {
+            manager.add(BucketItem(kind: .text, text: "\(i)"), source: .panel)
+        }
+        // After adding 0, 1, 2, 3, 4 (each inserted at head), items should be [4, 3, 2, 1, 0].
+        // Eviction keeps newest 3: [4, 3, 2]
+        XCTAssertEqual(manager.activeBucket.items.count, 3)
+        XCTAssertEqual(manager.activeBucket.items.map(\.text), ["4", "3", "2"])
+    }
+
+    func testLRUSparesPinnedItems() {
+        var s = manager.settings
+        s.maxItems = 2
+        manager.updateSettings(s)
+
+        let oldPinned = BucketItem(kind: .text, text: "old-pinned")
+        manager.add(oldPinned, source: .panel)
+        manager.togglePin(id: oldPinned.id)
+
+        for i in 0..<5 {
+            manager.add(BucketItem(kind: .text, text: "new-\(i)"), source: .panel)
+        }
+
+        // Pinned stays, plus newest unpinned up to the cap.
+        XCTAssertTrue(manager.activeBucket.items.contains { $0.text == "old-pinned" && $0.pinned })
+        XCTAssertEqual(manager.activeBucket.items.count, 2)
+    }
+
+    // MARK: - LRU by size
+
+    func testLRUEvictionBySize() {
+        var s = manager.settings
+        s.maxItems = 1000   // high, so count cap doesn't kick in
+        s.maxStorageBytes = 2500
+        manager.updateSettings(s)
+
+        func makeFile(_ size: Int64, name: String) -> BucketItem {
+            BucketItem(
+                kind: .file,
+                fileRef: .init(
+                    originalPath: "/tmp/\(name)",
+                    cachedPath: nil,
+                    byteSize: size,
+                    uti: "public.data",
+                    displayName: name
+                )
+            )
+        }
+
+        manager.add(makeFile(1000, name: "a"), source: .panel)
+        manager.add(makeFile(1000, name: "b"), source: .panel)
+        manager.add(makeFile(1000, name: "c"), source: .panel) // total 3000 > 2500
+
+        // Oldest ("a") should have been evicted. Items newest-first.
+        let names = manager.activeBucket.items.compactMap { $0.fileRef?.displayName }
+        XCTAssertFalse(names.contains("a"))
+        XCTAssertTrue(names.contains("b"))
+        XCTAssertTrue(names.contains("c"))
+    }
+
+    // MARK: - Search
+
+    func testSearchMatchesText() {
+        manager.add(BucketItem(kind: .text, text: "error log one"), source: .panel)
+        manager.add(BucketItem(kind: .text, text: "unrelated"), source: .panel)
+        let hits = manager.search("error")
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits.first?.text, "error log one")
+    }
+
+    func testSearchMatchesURLTitle() {
+        manager.add(
+            BucketItem(kind: .url, urlMeta: .init(urlString: "https://a.test", title: "Swift Docs")),
+            source: .panel
+        )
+        manager.add(
+            BucketItem(kind: .url, urlMeta: .init(urlString: "https://b.test", title: "Weather")),
+            source: .panel
+        )
+        let hits = manager.search("swift")
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits.first?.urlMeta?.title, "Swift Docs")
+    }
+
+    func testSearchMatchesFileName() {
+        let item = BucketItem(
+            kind: .file,
+            fileRef: .init(
+                originalPath: "/tmp/report.pdf",
+                cachedPath: nil,
+                byteSize: 100,
+                uti: "com.adobe.pdf",
+                displayName: "report.pdf"
+            )
+        )
+        manager.add(item, source: .panel)
+        XCTAssertEqual(manager.search("report").count, 1)
+        XCTAssertEqual(manager.search("pdf").count, 1)
+    }
+
+    func testSearchEmptyQueryReturnsAll() {
+        manager.add(BucketItem(kind: .text, text: "one"), source: .panel)
+        manager.add(BucketItem(kind: .text, text: "two"), source: .panel)
+        XCTAssertEqual(manager.search("").count, 2)
+        XCTAssertEqual(manager.search("   ").count, 2)
+    }
+
+    // MARK: - Persistence
+
+    func testPersistSurvivesReload() async throws {
+        let item = BucketItem(kind: .text, text: "persistent")
+        manager.add(item, source: .panel)
+        await manager.flushForTests()
+
+        // Rebuild manager pointing at the same store.
+        let store = BucketStore(rootURL: tempRoot)
+        let fresh = BucketManager(store: store)
+        fresh.load()
+        // load() is fire-and-forget; wait for it.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(fresh.activeBucket.items.count, 1)
+        XCTAssertEqual(fresh.activeBucket.items.first?.text, "persistent")
+    }
+}

--- a/Tests/BucketManagerTests.swift
+++ b/Tests/BucketManagerTests.swift
@@ -220,4 +220,51 @@ final class BucketManagerTests: XCTestCase {
         XCTAssertEqual(fresh.activeBucket.items.count, 1)
         XCTAssertEqual(fresh.activeBucket.items.first?.text, "persistent")
     }
+
+    // MARK: - Async file + image add (BLOCKER-3 fix)
+
+    func testAddFileAtURLCopiesSidecar() async throws {
+        let src = tempRoot.appendingPathComponent("source.txt")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try "hello".data(using: .utf8)!.write(to: src)
+
+        await manager.add(fileAt: src, source: .panel)
+
+        XCTAssertEqual(manager.activeBucket.items.count, 1)
+        let item = manager.activeBucket.items[0]
+        XCTAssertEqual(item.kind, .file)
+        XCTAssertEqual(item.fileRef?.originalPath, src.path)
+        let cached = try XCTUnwrap(item.fileRef?.cachedPath)
+        XCTAssertTrue(cached.hasPrefix("files/"))
+        let absolute = tempRoot.appendingPathComponent(cached)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: absolute.path))
+        XCTAssertEqual(try Data(contentsOf: absolute), "hello".data(using: .utf8))
+    }
+
+    func testAddImageDataWritesSidecar() async throws {
+        await manager.add(imageData: Data([0x89, 0x50, 0x4E, 0x47]), source: .panel)
+
+        XCTAssertEqual(manager.activeBucket.items.count, 1)
+        let item = manager.activeBucket.items[0]
+        XCTAssertEqual(item.kind, .image)
+        let cached = try XCTUnwrap(item.fileRef?.cachedPath)
+        XCTAssertTrue(cached.hasPrefix("images/"))
+        let absolute = tempRoot.appendingPathComponent(cached)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: absolute.path))
+    }
+
+    // MARK: - flushPendingWrites (SHOULD-2 fix)
+
+    func testFlushPendingWritesPersistsImmediately() async throws {
+        manager.add(BucketItem(kind: .text, text: "not-yet-written"), source: .panel)
+        // No flush yet — a fresh manager wouldn't see this because the 500ms
+        // debounce hasn't fired.
+
+        await manager.flushPendingWrites()
+
+        let store = BucketStore(rootURL: tempRoot)
+        let loaded = try await store.loadBucket()
+        XCTAssertEqual(loaded.items.count, 1)
+        XCTAssertEqual(loaded.items[0].text, "not-yet-written")
+    }
 }

--- a/Tests/BucketStoreTests.swift
+++ b/Tests/BucketStoreTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import SnorOhSwift
+
+final class BucketStoreTests: XCTestCase {
+
+    var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bucket-store-test-\(UUID().uuidString)")
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+        try await super.tearDown()
+    }
+
+    // MARK: - Manifest round-trip
+
+    func testLoadReturnsEmptyBucketWhenMissing() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let bucket = try await store.loadBucket()
+        XCTAssertTrue(bucket.items.isEmpty)
+        XCTAssertEqual(bucket.name, "Default")
+    }
+
+    func testSaveAndLoadRoundTrip() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let original = Bucket(
+            name: "Work",
+            items: [
+                BucketItem(kind: .text, text: "hello"),
+                BucketItem(kind: .url, urlMeta: .init(urlString: "https://x.test", title: "X")),
+            ]
+        )
+        try await store.saveBucket(original)
+        let loaded = try await store.loadBucket()
+        XCTAssertEqual(loaded.id, original.id)
+        XCTAssertEqual(loaded.name, "Work")
+        XCTAssertEqual(loaded.items.count, 2)
+        XCTAssertEqual(loaded.items[0].text, "hello")
+        XCTAssertEqual(loaded.items[1].urlMeta?.urlString, "https://x.test")
+    }
+
+    // MARK: - Settings round-trip
+
+    func testSettingsDefaultWhenMissing() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let s = try await store.loadSettings()
+        XCTAssertEqual(s.maxItems, 200)
+    }
+
+    func testSettingsRoundTrip() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        var s = BucketSettings()
+        s.captureClipboard = false
+        s.ignoredBundleIDs = ["com.example.app"]
+        try await store.saveSettings(s)
+        let loaded = try await store.loadSettings()
+        XCTAssertFalse(loaded.captureClipboard)
+        XCTAssertEqual(loaded.ignoredBundleIDs, ["com.example.app"])
+    }
+
+    // MARK: - Sidecar copy
+
+    func testCopySidecarFromFile() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let src = tempRoot.appendingPathComponent("source.txt")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try "hello".data(using: .utf8)!.write(to: src)
+
+        let itemID = UUID()
+        let rel = try await store.copySidecar(from: src, itemID: itemID, subdir: "files")
+
+        XCTAssertTrue(rel.hasPrefix("files/"))
+        XCTAssertTrue(rel.hasSuffix("\(itemID.uuidString).txt"))
+
+        let absolute = store.absoluteURL(forRelative: rel)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: absolute.path))
+        XCTAssertEqual(try Data(contentsOf: absolute), "hello".data(using: .utf8))
+
+        // Copy (not move) — source still exists
+        XCTAssertTrue(FileManager.default.fileExists(atPath: src.path))
+    }
+
+    func testMoveSidecar() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let src = tempRoot.appendingPathComponent("source.png")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try Data([0xDE, 0xAD, 0xBE, 0xEF]).write(to: src)
+
+        let rel = try await store.copySidecar(from: src, itemID: UUID(), subdir: "images", move: true)
+
+        XCTAssertTrue(rel.hasPrefix("images/"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: src.path),
+                       "Source should be removed after move")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.absoluteURL(forRelative: rel).path))
+    }
+
+    func testWriteSidecarRawBytes() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let rel = try await store.writeSidecar(
+            Data([1, 2, 3, 4]),
+            itemID: UUID(),
+            subdir: "images",
+            ext: "png"
+        )
+        let absolute = store.absoluteURL(forRelative: rel)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: absolute.path))
+        XCTAssertEqual(try Data(contentsOf: absolute), Data([1, 2, 3, 4]))
+    }
+
+    // MARK: - Delete sidecars
+
+    func testDeleteSidecarsRemovesFiles() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let src = tempRoot.appendingPathComponent("src.txt")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try "x".data(using: .utf8)!.write(to: src)
+
+        let rel1 = try await store.copySidecar(from: src, itemID: UUID(), subdir: "files")
+        let rel2 = try await store.copySidecar(from: src, itemID: UUID(), subdir: "files")
+
+        await store.deleteSidecars(relativePaths: [rel1, rel2])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.absoluteURL(forRelative: rel1).path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.absoluteURL(forRelative: rel2).path))
+    }
+
+    func testDeleteSidecarsIgnoresMissing() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        // Should not throw
+        await store.deleteSidecars(relativePaths: ["files/nonexistent.txt"])
+    }
+
+    // MARK: - Storage size
+
+    func testSidecarStorageBytesSumsAcrossSubdirs() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        _ = try await store.writeSidecar(Data(count: 1000), itemID: UUID(), subdir: "files", ext: "bin")
+        _ = try await store.writeSidecar(Data(count: 2000), itemID: UUID(), subdir: "images", ext: "png")
+        _ = try await store.writeSidecar(Data(count: 500), itemID: UUID(), subdir: "favicons", ext: "ico")
+
+        let total = await store.sidecarStorageBytes()
+        XCTAssertEqual(total, 3500)
+    }
+
+    // MARK: - Atomic write
+
+    func testAtomicWriteOverwritesExisting() async throws {
+        let store = BucketStore(rootURL: tempRoot)
+        let b1 = Bucket(name: "First", items: [])
+        try await store.saveBucket(b1)
+
+        let b2 = Bucket(name: "Second", items: [BucketItem(kind: .text, text: "x")])
+        try await store.saveBucket(b2)
+
+        let loaded = try await store.loadBucket()
+        XCTAssertEqual(loaded.name, "Second")
+        XCTAssertEqual(loaded.items.count, 1)
+    }
+}

--- a/Tests/BucketTypesTests.swift
+++ b/Tests/BucketTypesTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import SnorOhSwift
+
+final class BucketTypesTests: XCTestCase {
+
+    // MARK: - BucketItem round-trip per kind
+
+    func testCodableRoundTripFile() throws {
+        let item = BucketItem(
+            kind: .file,
+            sourceBundleID: "com.apple.finder",
+            fileRef: .init(
+                originalPath: "/tmp/foo.txt",
+                cachedPath: "files/abc.txt",
+                byteSize: 1024,
+                uti: "public.plain-text",
+                displayName: "foo.txt"
+            )
+        )
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripText() throws {
+        let item = BucketItem(kind: .text, text: "hello world")
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripRichText() throws {
+        let item = BucketItem(kind: .richText, text: "base64-rtf-here")
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripURL() throws {
+        let item = BucketItem(
+            kind: .url,
+            urlMeta: .init(
+                urlString: "https://example.com",
+                title: "Example",
+                faviconPath: "favicons/ab.ico",
+                ogImagePath: "og/cd.jpg"
+            )
+        )
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripImage() throws {
+        let item = BucketItem(
+            kind: .image,
+            fileRef: .init(
+                originalPath: "/tmp/shot.png",
+                cachedPath: "images/xx.png",
+                byteSize: 42_000,
+                uti: "public.png",
+                displayName: "shot.png"
+            )
+        )
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripColor() throws {
+        let item = BucketItem(kind: .color, colorHex: "#FF9500")
+        try assertCodableRoundTrip(item)
+    }
+
+    func testCodableRoundTripFolder() throws {
+        let item = BucketItem(
+            kind: .folder,
+            fileRef: .init(
+                originalPath: "/tmp/project",
+                cachedPath: nil,
+                byteSize: 0,
+                uti: "public.folder",
+                displayName: "project"
+            )
+        )
+        try assertCodableRoundTrip(item)
+    }
+
+    // MARK: - Bucket round-trip
+
+    func testBucketRoundTrip() throws {
+        let bucket = Bucket(
+            name: "Default",
+            items: [
+                BucketItem(kind: .text, text: "hello"),
+                BucketItem(kind: .url, urlMeta: .init(urlString: "https://a.test", title: nil)),
+            ]
+        )
+        let data = try JSONEncoder().encode(bucket)
+        let decoded = try JSONDecoder().decode(Bucket.self, from: data)
+        XCTAssertEqual(decoded.id, bucket.id)
+        XCTAssertEqual(decoded.name, bucket.name)
+        XCTAssertEqual(decoded.items, bucket.items)
+    }
+
+    // MARK: - Settings forward-compat
+
+    func testSettingsDecodesWithMissingFields() throws {
+        // Older on-disk JSON with no fields at all still decodes with defaults.
+        let minimal = Data("{}".utf8)
+        let decoded = try JSONDecoder().decode(BucketSettings.self, from: minimal)
+        XCTAssertEqual(decoded.maxItems, 200)
+        XCTAssertEqual(decoded.maxStorageBytes, 100_000_000)
+        XCTAssertTrue(decoded.captureClipboard)
+        XCTAssertTrue(decoded.ignoredBundleIDs.isEmpty)
+        XCTAssertEqual(decoded.autoHideSeconds, 2.0)
+        XCTAssertEqual(decoded.preferredEdge, .right)
+        XCTAssertEqual(decoded.hotkey.key, "B")
+        XCTAssertEqual(decoded.hotkey.modifiers, [.control, .option])
+    }
+
+    func testSettingsRoundTrip() throws {
+        let s = BucketSettings(
+            maxItems: 50,
+            maxStorageBytes: 1_000_000,
+            captureClipboard: false,
+            ignoredBundleIDs: ["com.1password.1password"],
+            autoHideSeconds: 5,
+            preferredEdge: .left,
+            hotkey: HotkeyBinding(key: "K", modifiers: [.command, .shift])
+        )
+        let data = try JSONEncoder().encode(s)
+        let decoded = try JSONDecoder().decode(BucketSettings.self, from: data)
+        XCTAssertEqual(decoded.maxItems, s.maxItems)
+        XCTAssertEqual(decoded.maxStorageBytes, s.maxStorageBytes)
+        XCTAssertEqual(decoded.captureClipboard, s.captureClipboard)
+        XCTAssertEqual(decoded.ignoredBundleIDs, s.ignoredBundleIDs)
+        XCTAssertEqual(decoded.autoHideSeconds, s.autoHideSeconds)
+        XCTAssertEqual(decoded.preferredEdge, s.preferredEdge)
+        XCTAssertEqual(decoded.hotkey, s.hotkey)
+    }
+
+    // MARK: - HotkeyBinding modifier set order-independence
+
+    func testHotkeyBindingSetOrderIndependence() {
+        let a = HotkeyBinding(key: "B", modifiers: [.control, .option])
+        let b = HotkeyBinding(key: "B", modifiers: [.option, .control])
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - Default item timestamps
+
+    func testBucketItemDefaultsLastAccessedToCreatedAt() {
+        let now = Date()
+        let item = BucketItem(kind: .text, createdAt: now, text: "x")
+        XCTAssertEqual(item.lastAccessedAt, now)
+    }
+
+    // MARK: - Helpers
+
+    private func assertCodableRoundTrip<T: Codable & Equatable>(_ value: T) throws {
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(T.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+}


### PR DESCRIPTION
Closes #1.

## Summary

First working version of the **Bucket** feature — a universal shelf that sits inside the existing snor-oh panel and on the mascot itself. Accepts anything draggable (files, folders, URLs, images, plain text, RTF, colors), auto-captures the clipboard, and lets the user drag items back out to any destination. Ships behind a global hotkey (⌃⌥B) and a menu-bar count badge.

## What landed (6 commits)

| Phase | Commit | Delivers |
|---|---|---|
| 1 | Types & Storage | `BucketItem` / `Bucket` / `BucketSettings` Codable types, `BucketStore` actor owning `~/.snor-oh/buckets/` with atomic JSON writes + sidecar copy, 23 tests |
| 2 | State & infra | `BucketManager` @Observable @MainActor singleton, `BucketDropHandler` (NSItemProvider → BucketItem), `ClipboardMonitor`, `URLMetadataFetcher`, Carbon `HotkeyRegistrar`, 16 more tests |
| 3 | UI | `BucketView` (search + list + drop zone), `BucketCardView` (per-kind cards + drag-out + hover pin/delete), panel tab switcher, `.onDrop` on mascot sprite, Settings → Bucket tab |
| 4 | Integration | AppDelegate wires clipboard monitor + hotkey + status-bar bucket badge + first-launch tip; @MainActor annotation |
| 5 | Review fixes | Sidecar-copy-before-insert, Quick Look via QLPreviewPanel, flush-on-quit, source-param on remove/pin/clear, self-capture suppression, live-bound settings UI, 3 more tests |
| 6 | QL isolation cleanup | One-line Swift 6 isolation fix on QuickLookPreviewer |

## Stats

- **22 files changed** (14 new + 8 modified)
- **~2,850 lines** of Swift source + **~570 lines** of tests
- **61 tests pass** (19 existing + 42 new) — `swift test` green
- **Release build succeeds** — 21MB universal binary (x86_64 + arm64)
- **Code reviewed** by `ecc:code-reviewer` agent; all 3 blockers + 4 should-fixes addressed

## Acceptance criteria (from issue #1)

- [x] Drop any of: file, folder, image bytes, URL, plain text, RTF, color
- [x] Mascot accepts same UTTypes as panel (`MascotView` + `SnorOhPanelView.mascotStage`)
- [x] Drag-out with Finder modifiers (⌥ copy / ⌘ move, default copy)
- [x] Clipboard dedupes identical consecutive copies
- [x] Per-app ignore list (bundle ID)
- [x] Pinned items never evict; LRU by count + by size (both spare pinned)
- [x] Search across text, file name, URL, title, `sourceBundleID`
- [x] Stack multi-file drops (shared `stackGroupID`)
- [x] Quick Look via spacebar on focused card
- [x] Global hotkey ⌃⌥B + menu-bar click toggle
- [x] Rich previews (thumbnail / file icon / color swatch)
- [x] First-launch tip bubble, one-time
- [x] Menu-bar bucket-count badge (orange)
- [x] Dark / light / system theme match
- [x] Panel position / edge / tab persisted
- [x] `.bucketChanged` userInfo contract (`source`, `change`, `itemID`) — unblocks Epic 02

## Deliberately deferred

- **URL metadata auto-fetch on drop** — `URLMetadataFetcher` exists but isn't wired into the drop path; URL cards currently show a generic icon. Flagged as NICE-TO-HAVE in review. Add when the first user asks for it or when Epic 02 makes the card look cheaper.
- **Hotkey rebind UI** — Settings shows static `⌃⌥B` hint. `HotkeyBinding` type + `HotkeyRegistrar` already support rebinding; only the Settings text-capture field is missing.
- **Pre-existing Swift 6 actor-isolation warnings** — surfaced (not introduced) by adding `@MainActor` to `AppDelegate`. Live in `mcpReactObserver` closures. Reviewer explicitly said defer.

## Architecture notes for reviewer

- **`BucketStore` is an actor**, exclusively owns disk I/O. `BucketManager` is `@MainActor @Observable`, so all mutation sites + UI reads happen on main without blocking. Follows the `ecc:swift-actor-persistence` pattern.
- **Debounced persist** — every mutation schedules a 500 ms debounced write via `BucketStore`. `applicationWillTerminate` uses a semaphore-bounded 500ms wait to flush pending writes before quit (SHOULD-FIX #2 from review).
- **`.bucketChanged` source contract** — every `.bucketChanged` notification carries `userInfo["source"]` (`"panel" | "mascot" | "clipboard"` in Epic 01; `"screenshot" | "peer" | …` come in later epics). This is the contract Epic 02 depends on — see `docs/prd/bucket/REVIEW.md` §6.
- **Sidecar copy happens BEFORE insert** — `BucketManager.add(fileAt:)` + `add(imageData:)` are async; they copy into sidecar then insert with `cachedPath` populated, so drag-in items survive restart. Fixes review BLOCKER-3.
- **@MainActor on AppDelegate** — necessary for clean access to `BucketManager.shared`. Surfaces pre-existing actor-isolation warnings in `mcpReactObserver` closures — those are NOT regressions (same code exists on `main`), flagged for a dedicated cleanup pass.

## Smoke test checklist (GUI — needs human)

1. `open .build/release-app/snor-oh.app`
2. First launch → "Drop anything onto me to bucket it!" bubble appears
3. `⌃⌥B` → panel toggles + focuses Bucket tab
4. Drag a file from Finder onto the mascot → file card appears with icon + name + size
5. Drag URL from Safari onto bucket tab → URL card
6. `⌘C` text in another app → auto-captured as text card (honors ignore list)
7. Hover card → pin + delete buttons appear
8. Select card + spacebar → Quick Look opens (files + images)
9. Drag a card out into Finder (default copy; `⌘` for move)
10. Menu-bar icon shows `●N` orange dot when bucket has items
11. Settings → Bucket → sliders move live with `manager.settings`
12. Quit + relaunch → bucket contents + position + settings persist

## Follow-up after merge

- Close issue #1
- Unblocks Epic 02 (mascot catch reaction) — its only hard dep is the `.bucketChanged` contract now in place
- Consider wiring `URLMetadataFetcher` as a small follow-up PR if users ask for rich URL cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)